### PR TITLE
New activity states and state machine

### DIFF
--- a/BloogBot.AI/Annotations/ActivityPluginAttribute.cs
+++ b/BloogBot.AI/Annotations/ActivityPluginAttribute.cs
@@ -1,0 +1,11 @@
+using BloogBot.AI.States;
+
+namespace BloogBot.AI.Annotations;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class ActivityPluginAttribute : Attribute
+{
+    public BotActivity Activity { get; }
+
+    public ActivityPluginAttribute(BotActivity activity) => Activity = activity;
+}

--- a/BloogBot.AI/BloogBot.AI.csproj
+++ b/BloogBot.AI/BloogBot.AI.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+      <PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.54.0" />
+      <PackageReference Include="Stateless" Version="5.17.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Exports\GameData.Core\GameData.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/BloogBot.AI/Semantic/DictionaryExtensions.cs
+++ b/BloogBot.AI/Semantic/DictionaryExtensions.cs
@@ -1,0 +1,9 @@
+namespace BloogBot.AI.Semantic;
+
+static class DictionaryExtensions
+{
+    public static List<TValue> GetOrAdd<TKey, TValue>(
+        this Dictionary<TKey, List<TValue>> d,
+        TKey key
+    ) => d.TryGetValue(key, out var v) ? v : (d[key] = new List<TValue>());
+}

--- a/BloogBot.AI/Semantic/KernelCoordinator.cs
+++ b/BloogBot.AI/Semantic/KernelCoordinator.cs
@@ -1,0 +1,22 @@
+using BloogBot.AI.Semantic;
+using BloogBot.AI.States;
+using Microsoft.SemanticKernel;
+
+public sealed class KernelCoordinator
+{
+    private readonly Kernel _kernel;
+    private readonly PluginCatalog _catalog;
+
+    public KernelCoordinator(Kernel kernel, PluginCatalog catalog)
+    {
+        _kernel = kernel;
+        _catalog = catalog;
+    }
+
+    public void OnActivityChanged(BotActivity newActivity)
+    {
+        _kernel.Plugins.Clear();
+        foreach (var p in _catalog.For(newActivity))
+            _kernel.Plugins.Add(p);
+    }
+}

--- a/BloogBot.AI/Semantic/PluginCatalog.cs
+++ b/BloogBot.AI/Semantic/PluginCatalog.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using BloogBot.AI.Annotations;
+using BloogBot.AI.States;
+using Microsoft.SemanticKernel;
+
+namespace BloogBot.AI.Semantic;
+
+public sealed class PluginCatalog
+{
+    readonly Dictionary<BotActivity, List<KernelPlugin>> _byActivity = new();
+
+    public PluginCatalog()
+    {
+        var types = AppDomain
+            .CurrentDomain.GetAssemblies()
+            .SelectMany(a => a.GetTypes())
+            .Where(t => t.GetCustomAttributes<ActivityPluginAttribute>().Any());
+
+        foreach (var t in types)
+        {
+            var plugin = KernelPluginFactory.CreateFromObject(t, t.Name);
+            foreach (var attr in t.GetCustomAttributes<ActivityPluginAttribute>())
+                _byActivity.GetOrAdd(attr.Activity).Add(plugin);
+        }
+    }
+
+    public IReadOnlyList<KernelPlugin> For(BotActivity activity) =>
+        _byActivity.TryGetValue(activity, out var list) ? list : Array.Empty<KernelPlugin>();
+}
+
+// helper extension
+static class DictionaryExtensions
+{
+    public static List<TValue> GetOrAdd<TKey, TValue>(
+        this Dictionary<TKey, List<TValue>> d,
+        TKey key
+    ) => d.TryGetValue(key, out var v) ? v : (d[key] = new List<TValue>());
+}

--- a/BloogBot.AI/Semantic/PluginCatalog.cs
+++ b/BloogBot.AI/Semantic/PluginCatalog.cs
@@ -27,12 +27,3 @@ public sealed class PluginCatalog
     public IReadOnlyList<KernelPlugin> For(BotActivity activity) =>
         _byActivity.TryGetValue(activity, out var list) ? list : Array.Empty<KernelPlugin>();
 }
-
-// helper extension
-static class DictionaryExtensions
-{
-    public static List<TValue> GetOrAdd<TKey, TValue>(
-        this Dictionary<TKey, List<TValue>> d,
-        TKey key
-    ) => d.TryGetValue(key, out var v) ? v : (d[key] = new List<TValue>());
-}

--- a/BloogBot.AI/StateMachine/BotActivityStateMachine.cs
+++ b/BloogBot.AI/StateMachine/BotActivityStateMachine.cs
@@ -1,0 +1,49 @@
+using BloogBot.AI.States;
+using GameData.Core.Interfaces;
+using Microsoft.Extensions.Logging;
+using Stateless;
+
+namespace BloogBot.AI.StateMachine;
+
+public sealed class BotActivityStateMachine
+{
+    private readonly StateMachine<BotActivity, Trigger> _sm;
+    public BotActivity Current => _sm.State;
+    public IObjectManager ObjectManager { get; private set; }
+    private ILogger Logger;
+
+    public BotActivityStateMachine(
+        ILoggerFactory loggerFactory,
+        IObjectManager objectManager,
+        BotActivity initial = BotActivity.Resting
+    )
+    {
+        Logger = loggerFactory.CreateLogger<BotActivityStateMachine>();
+        ObjectManager = objectManager;
+        _sm = new(initial);
+
+        ConfigureResting();
+        ConfigureQuesting();
+        // … repeat for each activity
+    }
+
+    void ConfigureResting() =>
+        _sm.Configure(BotActivity.Resting)
+            .PermitDynamic(Trigger.HealthRestored, DecideNextActiveState);
+
+    void ConfigureQuesting() =>
+        _sm.Configure(BotActivity.Questing)
+            .OnEntry(ctx => Logger.LogInformation("Starting quest"))
+            .Permit(Trigger.LowHealth, BotActivity.Resting);
+
+    BotActivity DecideNextActiveState() =>
+        ObjectManager.Player.InBattleground ? BotActivity.Battlegrounding
+        : ObjectManager.Player.HasQuestTargets ? BotActivity.Questing
+        : BotActivity.Grinding;
+}
+
+internal enum Trigger
+{
+    HealthRestored,
+    LowHealth,
+}

--- a/BloogBot.AI/States/BotActivity.cs
+++ b/BloogBot.AI/States/BotActivity.cs
@@ -1,0 +1,44 @@
+﻿namespace BloogBot.AI.States;
+
+public enum BotActivity
+{
+    // --- Character Development
+    Questing,
+    Grinding,
+    Professions,
+    Talenting,
+    Equipping,
+
+    // --- Social
+    Trading,
+    Guilding,
+    Chatting,
+    Helping,
+    Mailing,
+    Partying,
+    RolePlaying,
+
+    // --- Combat & PvP
+    Combat,
+    Battlegrounding,
+    Dungeoning,
+    Raiding,
+    WorldPvPing,
+    Camping,
+
+    // --- Economy
+    Auction,
+    Banking,
+    Vending,
+
+    // --- Movement
+    Exploring,
+    Traveling,
+    Escaping,
+
+    // --- Passive
+    Resting,
+
+    // --- Events
+    Eventing,
+}

--- a/Exports/GameData.Core/Interfaces/IWoWLocalPlayer.cs
+++ b/Exports/GameData.Core/Interfaces/IWoWLocalPlayer.cs
@@ -18,5 +18,7 @@ namespace GameData.Core.Interfaces
         uint Copper { get; }
         bool IsAutoAttacking { get; }
         bool CanResurrect { get; }
+        bool InBattleground { get; }
+        bool HasQuestTargets { get; }
     }
 }

--- a/Exports/WoWSharpClient/Models/WoWLocalPlayer.cs
+++ b/Exports/WoWSharpClient/Models/WoWLocalPlayer.cs
@@ -4,7 +4,9 @@ using GameData.Core.Models;
 
 namespace WoWSharpClient.Models
 {
-    public class WoWLocalPlayer(HighGuid highGuid, WoWObjectType objectType = WoWObjectType.Player) : WoWPlayer(highGuid, objectType), IWoWLocalPlayer
+    public class WoWLocalPlayer(HighGuid highGuid, WoWObjectType objectType = WoWObjectType.Player)
+        : WoWPlayer(highGuid, objectType),
+            IWoWLocalPlayer
     {
         public Position CorpsePosition => throw new NotImplementedException();
         public bool InGhostForm => throw new NotImplementedException();
@@ -19,8 +21,10 @@ namespace WoWSharpClient.Models
         public bool MainhandIsEnchanted => throw new NotImplementedException();
         public uint Copper => throw new NotImplementedException();
         public bool IsAutoAttacking => throw new NotImplementedException();
-        public bool CanResurrect => throw new NotImplementedException(); 
-        
+        public bool CanResurrect => throw new NotImplementedException();
+        public bool InBattleground => throw new NotImplementedException();
+        public bool HasQuestTargets => throw new NotImplementedException();
+
         public override WoWLocalPlayer Clone()
         {
             var clone = new WoWLocalPlayer(this.HighGuid, this.ObjectType);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 # BloogBot Project Overview
+=======
+# BloogBot Project Overview (Root README)
+>>>>>>> a3cfe7c (Update README.md)
 
 **BloogBot** is a modular **World of Warcraft bot** framework designed for developers to extend and customize. It operates by injecting a .NET bot into the WoW game client, enabling automated gameplay on legacy WoW versions (Vanilla 1.12.1, TBC 2.4.3, WotLK 3.3.5). This project is composed of several components, each handling a different aspect of the bot’s functionality. This overview will describe the architecture at a high level and provide links to detailed documentation for each part.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 # BloogBot Project Overview
-=======
-# BloogBot Project Overview (Root README)
->>>>>>> a3cfe7c (Update README.md)
 
 **BloogBot** is a modular **World of Warcraft bot** framework designed for developers to extend and customize. It operates by injecting a .NET bot into the WoW game client, enabling automated gameplay on legacy WoW versions (Vanilla 1.12.1, TBC 2.4.3, WotLK 3.3.5). This project is composed of several components, each handling a different aspect of the bot’s functionality. This overview will describe the architecture at a high level and provide links to detailed documentation for each part.
 

--- a/Services/ForegroundBotRunner/Objects/LocalPlayer.cs
+++ b/Services/ForegroundBotRunner/Objects/LocalPlayer.cs
@@ -9,27 +9,30 @@ namespace ForegroundBotRunner.Objects
 {
     public class LocalPlayer : WoWPlayer, IWoWLocalPlayer
     {
-        internal LocalPlayer(
-            nint pointer,
-            HighGuid guid,
-            WoWObjectType objectType)
+        internal LocalPlayer(nint pointer, HighGuid guid, WoWObjectType objectType)
             : base(pointer, guid, objectType) { }
 
         public readonly IDictionary<string, int[]> PlayerSpells = new Dictionary<string, int[]>();
         public readonly List<int> PlayerSkills = [];
         public new ulong TargetGuid => MemoryManager.ReadUlong(Offsets.Player.TargetGuid, true);
 
-        public static bool TargetInMeleeRange => Functions.LuaCallWithResult("{0} = CheckInteractDistance(\"target\", 3)")[0] == "1";
+        public static bool TargetInMeleeRange =>
+            Functions.LuaCallWithResult("{0} = CheckInteractDistance(\"target\", 3)")[0] == "1";
 
         public new Class Class => (Class)MemoryManager.ReadByte(MemoryAddresses.LocalPlayerClass);
-        public new Race Race => Enum.GetValues(typeof(Race))
+        public new Race Race =>
+            Enum.GetValues(typeof(Race))
                 .Cast<Race>()
-            .FirstOrDefault(v => v.GetDescription() == Functions.LuaCallWithResult("{0} = UnitRace('player')")[0]);
+                .FirstOrDefault(v =>
+                    v.GetDescription() == Functions.LuaCallWithResult("{0} = UnitRace('player')")[0]
+                );
 
-        public Position CorpsePosition => new(
-            MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionX),
-            MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionY),
-            MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionZ));
+        public Position CorpsePosition =>
+            new(
+                MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionX),
+                MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionY),
+                MemoryManager.ReadFloat(MemoryAddresses.LocalPlayerCorpsePositionZ)
+            );
 
         public string CurrentStance
         {
@@ -90,14 +93,16 @@ namespace ForegroundBotRunner.Objects
             }
         }
 
-        public bool IsDiseased => GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Disease);
+        public bool IsDiseased =>
+            GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Disease);
 
         public bool IsCursed => GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Curse);
 
-        public bool IsPoisoned => GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Poison);
+        public bool IsPoisoned =>
+            GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Poison);
 
-        public bool HasMagicDebuff => GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Magic);
-
+        public bool HasMagicDebuff =>
+            GetDebuffs(LuaTarget.Player).Any(t => t.Type == EffectType.Magic);
 
         public int GetSpellId(string spellName, int rank = -1)
         {
@@ -129,14 +134,16 @@ namespace ForegroundBotRunner.Objects
             if (parId >= MemoryManager.ReadUint(0x00C0D780 + 0xC) || parId <= 0)
                 return 0;
 
-            var entryPtr = MemoryManager.ReadIntPtr((nint)(uint)(MemoryManager.ReadUint(0x00C0D780 + 8) + parId * 4));
+            var entryPtr = MemoryManager.ReadIntPtr(
+                (nint)(uint)(MemoryManager.ReadUint(0x00C0D780 + 8) + parId * 4)
+            );
             return MemoryManager.ReadInt(entryPtr + 0x0080);
-
         }
 
         public bool KnowsSpell(string name) => PlayerSpells.ContainsKey(name);
 
-        public bool MainhandIsEnchanted => Functions.LuaCallWithResult("{0} = GetWeaponEnchantInfo()")[0] == "1";
+        public bool MainhandIsEnchanted =>
+            Functions.LuaCallWithResult("{0} = GetWeaponEnchantInfo()")[0] == "1";
 
         public bool CanRiposte
         {
@@ -144,7 +151,9 @@ namespace ForegroundBotRunner.Objects
             {
                 if (PlayerSpells.ContainsKey("Riposte"))
                 {
-                    var results = Functions.LuaCallWithResult("{0}, {1} = IsUsableSpell('Riposte')");
+                    var results = Functions.LuaCallWithResult(
+                        "{0}, {1} = IsUsableSpell('Riposte')"
+                    );
                     if (results.Length > 0)
                         return results[0] == "1";
                     else
@@ -161,5 +170,7 @@ namespace ForegroundBotRunner.Objects
         public bool IsAutoAttacking => throw new NotImplementedException();
 
         public bool CanResurrect => throw new NotImplementedException();
+        public bool InBattleground => throw new NotImplementedException();
+        public bool HasQuestTargets => throw new NotImplementedException();
     }
 }

--- a/WestworldOfWarcraft.sln
+++ b/WestworldOfWarcraft.sln
@@ -19,8 +19,14 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WoWSharpClient", "Exports\WoWSharpClient\WoWSharpClient.csproj", "{0E823F6A-007F-4FAF-9819-B561347525EC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{A34E454D-EDFF-4AE3-806D-F17D3E19FF66}"
+	ProjectSection(SolutionItems) = preProject
+		Services\README.md = Services\README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Exports", "Exports", "{2B5ADD00-9FA5-4839-A06C-21FA6C02FE8E}"
+	ProjectSection(SolutionItems) = preProject
+		Exports\README.md = Exports\README.md
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotRunner", "Exports\BotRunner\BotRunner.csproj", "{C268D63C-9278-480E-B708-CA55FE09EEA3}"
 EndProject
@@ -56,6 +62,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameData.Core", "Exports\GameData.Core\GameData.Core.csproj", "{0CD771AA-583C-4037-93A4-1F5F472934A9}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BloogBot.AI", "BloogBot.AI\BloogBot.AI.csproj", "{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -405,6 +413,22 @@ Global
 		{0CD771AA-583C-4037-93A4-1F5F472934A9}.Release|x64.Build.0 = Release|Any CPU
 		{0CD771AA-583C-4037-93A4-1F5F472934A9}.Release|x86.ActiveCfg = Release|Any CPU
 		{0CD771AA-583C-4037-93A4-1F5F472934A9}.Release|x86.Build.0 = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|Win32.Build.0 = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|Win32.ActiveCfg = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|Win32.Build.0 = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|x64.Build.0 = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -431,6 +455,7 @@ Global
 		{90BF97BD-7BF3-47D3-A575-E9AD85FBE336} = {C359E65D-9D40-44E4-A256-4C75A6438CCA}
 		{7731A959-10DE-4F06-CBE3-2A9C0CE8B9C3} = {C359E65D-9D40-44E4-A256-4C75A6438CCA}
 		{0CD771AA-583C-4037-93A4-1F5F472934A9} = {2B5ADD00-9FA5-4839-A06C-21FA6C02FE8E}
+		{58CD6FF8-8AAD-455A-86FA-8678FB8C8C4A} = {A34E454D-EDFF-4AE3-806D-F17D3E19FF66}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D542335-5812-4666-9874-ACFCC515267C}


### PR DESCRIPTION
### summary
This code adds new activity states that cover gameplay modes (Questing, Camping, etc.), which drives a **Stateless** state machine. It also introduces an `[ActivityPlugin]` attribute to annotate SK plugin classes.

### co-pilot's summary
This pull request introduces a new `BloogBot.AI` project for managing bot activities in a structured and extensible way. Key changes include the addition of state management for bot activities, a plugin system for activity-specific behaviors, and integration with existing game data interfaces. Below is a breakdown of the most important changes:

### New Project and Configuration
* Added a new `BloogBot.AI` project to the solution (`WestworldOfWarcraft.sln`), including its project file with dependencies on `Microsoft.Extensions.Logging.Abstractions`, `Microsoft.SemanticKernel.Core`, and `Stateless`. [[1]](diffhunk://#diff-346e1f109e1ca943c3e36a447b3f94f7e5cc28661c400d18aa9680755aadd8e7R1-R19) [[2]](diffhunk://#diff-9523ae893c960937755e0330e5261fc64af8e10677b2df4f2ae37cb7da6e8f60R66-R67) [[3]](diffhunk://#diff-9523ae893c960937755e0330e5261fc64af8e10677b2df4f2ae37cb7da6e8f60R416-R431)

### State Management for Bot Activities
* Introduced the `BotActivityStateMachine` class to manage transitions between bot activities like `Resting`, `Questing`, and `Grinding` using the `Stateless` library.
* Added a `BotActivity` enum to define various bot activity types, grouped by themes such as combat, economy, and movement.

### Plugin System for Activity-Specific Behaviors
* Created the `ActivityPluginAttribute` to annotate plugins with the bot activity they support.
* Added the `PluginCatalog` class to dynamically load and manage plugins based on the current bot activity.
* Implemented the `KernelCoordinator` class to coordinate plugins with the `Microsoft.SemanticKernel`.

### Extensions and Utilities
* Added a `DictionaryExtensions` utility to simplify operations on dictionaries storing lists of values.

### Integration with Game Data
* Extended the `IWoWLocalPlayer` interface and its implementations (`WoWLocalPlayer` and `LocalPlayer`) to include properties like `InBattleground` and `HasQuestTargets`, enabling activity-specific logic. [[1]](diffhunk://#diff-a573933bdf5855e20659474a97485d4a67524ac8f3c6dea9dbc6791fd1aeda2dR21-R22) [[2]](diffhunk://#diff-1e5316ea11f9015d53cb453a63aec79621ac71aae33d6e0433299a58d2172f8eR25-R26) [[3]](diffhunk://#diff-b76afb352c10da1dbf625c8df59c2385ea2417ab3f30513c7bbc0d2ef025423cR173-R174)

These changes lay the groundwork for a modular and extensible bot framework, enabling better state management and activity-specific behaviors.

@QiMata @lrhodes404 