### PR TITLE
Rename MageFire bot class

### DIFF
--- a/BotProfiles/MageFire/MageFire.cs
+++ b/BotProfiles/MageFire/MageFire.cs
@@ -7,7 +7,7 @@ using MageFire.Tasks;
 namespace MageFire
 {
     [Export(typeof(IBot))]
-    internal class MageArcane : IBot
+    internal class MageFire : IBot
     {
         public string Name => "Fire Mage";
 
@@ -36,6 +36,6 @@ namespace MageFire
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }


### PR DESCRIPTION
## Summary
- rename `MageArcane` to `MageFire`
- return `PvPRotationTask` in `CreatePvPRotationTask`

## Testing
- `dotnet test --no-build` *(fails: missing Visual Studio build files and NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ad7d9a0c8832aa326e81222ead416