### PR TITLE
Fix PvPRotationTask creation

### DIFF
--- a/BotProfiles/PaladinHoly/PaladinHoly.cs
+++ b/BotProfiles/PaladinHoly/PaladinHoly.cs
@@ -36,6 +36,6 @@ namespace PaladinHoly
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }


### PR DESCRIPTION
## Summary
- construct `PvPRotationTask` for PvP rotation

## Testing
- `dotnet build --no-restore` *(fails: assets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad7e01d3c832a8ad92a76cf9f692f