### PR TITLE
Fix PvE rotation stubs

### DIFF
--- a/BotProfiles/MageArcane/Tasks/PvERotationTask.cs
+++ b/BotProfiles/MageArcane/Tasks/PvERotationTask.cs
@@ -22,7 +22,6 @@ namespace MageArcane.Tasks
             if (frostNovaBackpedaling)
                 return;
 
-
             if (!ObjectManager.Aggressors.Any())
             {
                 BotTasks.Pop();
@@ -34,6 +33,32 @@ namespace MageArcane.Tasks
                 ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
             }
 
+            ExecuteRotation();
+        }
+
+        public override void PerformCombatRotation()
+        {
+            if (frostNovaBackpedaling && Environment.TickCount - frostNovaBackpedalStartTime > 1500)
+            {
+                ObjectManager.Player.StopMovement(ControlBits.Back);
+                frostNovaBackpedaling = false;
+            }
+            if (frostNovaBackpedaling)
+                return;
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                if (ObjectManager.Aggressors.Any())
+                    ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                else
+                    return;
+            }
+
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
             if (Update(30))
                 return;
 
@@ -57,11 +82,6 @@ namespace MageArcane.Tasks
             TryCastSpell(Fireball, 0, 34, ObjectManager.Player.Level < 15 || ObjectManager.Player.HasBuff(PresenceOfMind));
 
             TryCastSpell(ArcaneMissiles, 0, 29, ObjectManager.Player.Level >= 15);
-        }
-
-        public override void PerformCombatRotation()
-        {
-            throw new NotImplementedException();
         }
 
         private Action FrostNovaCallback => () =>

--- a/BotProfiles/PaladinRetribution/Tasks/PvERotationTask.cs
+++ b/BotProfiles/PaladinRetribution/Tasks/PvERotationTask.cs
@@ -12,7 +12,15 @@ namespace PaladinRetribution.Tasks
 
         public override void PerformCombatRotation()
         {
-            throw new NotImplementedException();
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                if (ObjectManager.Aggressors.Any())
+                    ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                else
+                    return;
+            }
+
+            ExecuteRotation();
         }
 
         public void Update()
@@ -37,6 +45,11 @@ namespace PaladinRetribution.Tasks
             if (Update(3))
                 return;
 
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
             TryCastSpell(Purify, ObjectManager.Player.IsPoisoned || ObjectManager.Player.IsDiseased, castOnSelf: true);
 
             TryCastSpell(DevotionAura, !ObjectManager.Player.HasBuff(DevotionAura) && !ObjectManager.Player.IsSpellReady(RetributionAura) && !ObjectManager.Player.IsSpellReady(SanctityAura));
@@ -48,7 +61,7 @@ namespace PaladinRetribution.Tasks
             TryCastSpell(Exorcism, ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Undead || ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Demon);
 
             TryCastSpell(HammerOfJustice, ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Humanoid || (ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Humanoid && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20));
-            
+
             TryCastSpell(SealOfTheCrusader, !ObjectManager.Player.HasBuff(SealOfTheCrusader) && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(JudgementOfTheCrusader));
 
             TryCastSpell(SealOfRighteousness, !ObjectManager.Player.HasBuff(SealOfRighteousness) && ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(JudgementOfTheCrusader) && !ObjectManager.Player.IsSpellReady(SealOfCommand));

--- a/BotProfiles/ShamanElemental/Tasks/PvERotationTask.cs
+++ b/BotProfiles/ShamanElemental/Tasks/PvERotationTask.cs
@@ -16,7 +16,15 @@ namespace ShamanElemental.Tasks
 
         public override void PerformCombatRotation()
         {
-            throw new NotImplementedException();
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                if (ObjectManager.Aggressors.Any())
+                    ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                else
+                    return;
+            }
+
+            ExecuteRotation();
         }
 
         public void Update()
@@ -43,6 +51,11 @@ namespace ShamanElemental.Tasks
                 return;
             }
 
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
             TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting && ObjectManager.GetTarget(ObjectManager.Player).Mana > 0));
 
             TryCastSpell(EarthShock, 0, 20, !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling || ObjectManager.Player.HasBuff(Clearcasting)));

--- a/BotProfiles/WarriorArms/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarriorArms/Tasks/PvERotationTask.cs
@@ -34,7 +34,25 @@ namespace WarriorArms.Tasks
             if (Update(3))
                 return;
 
-            // Use these abilities when fighting any number of mobs.   
+            ExecuteRotation();
+        }
+
+        public override void PerformCombatRotation()
+        {
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                if (ObjectManager.Aggressors.Any())
+                    ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                else
+                    return;
+            }
+
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
+            // Use these abilities when fighting any number of mobs.
             TryUseAbility(Bloodrage, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
 
             TryUseAbilityById(BloodFury, 4, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
@@ -85,11 +103,6 @@ namespace WarriorArms.Tasks
                     TryUseAbility(HeroicStrike, ObjectManager.Player.Level < 30 ? 15 : 45, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
                 }
             }
-        }
-
-        public override void PerformCombatRotation()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/BotProfiles/WarriorFury/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarriorFury/Tasks/PvERotationTask.cs
@@ -69,67 +69,7 @@ namespace WarriorFury.Tasks
             if (Update(5))
                 return;
 
-            string currentStance = ObjectManager.Player.CurrentStance;
-            IEnumerable<IWoWUnit> spellcastingAggressors = ObjectManager.Aggressors
-                .Where(a => a.Mana > 0);
-            // Use these abilities when fighting any number of mobs.   
-            TryUseAbility(BerserkerStance, condition: ObjectManager.Player.Level >= 30 && currentStance == BattleStance && (ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 80 || ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Elemental || ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Undead));
-
-            TryUseAbility(Pummel, 10, currentStance == BerserkerStance && ObjectManager.GetTarget(ObjectManager.Player).Mana > 0 && (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling));
-
-            // TryUseAbility(Rend, 10, (currentStance == BattleStance && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) && (ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Elemental && ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Undead)));
-
-            TryUseAbility(DeathWish, 10, ObjectManager.Player.IsSpellReady(DeathWish) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
-
-            TryUseAbility(BattleShout, 10, !ObjectManager.Player.HasBuff(BattleShout));
-
-            TryUseAbilityById(BloodFury, 4, 0, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
-
-            TryUseAbility(Bloodrage, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
-
-            TryUseAbility(Execute, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20);
-
-            TryUseAbility(BerserkerRage, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 70 && currentStance == BerserkerStance);
-
-            TryUseAbility(Overpower, 5, currentStance == BattleStance && overpowerStopwatch.IsRunning);
-
-            // Use these abilities if you are fighting TWO OR MORE mobs at once.
-            if (ObjectManager.Aggressors.Count() >= 2)
-            {
-                TryUseAbility(IntimidatingShout, 25, !(ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(IntimidatingShout) || ObjectManager.Player.HasBuff(Retaliation)) && ObjectManager.Aggressors.All(a => a.Position.DistanceTo(ObjectManager.Player.Position) < 10));
-
-                TryUseAbility(DemoralizingShout, 10, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(DemoralizingShout));
-
-                // TryUseAbility(Cleave, 20, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && FacingAllTargets);
-
-                TryUseAbility(Whirlwind, 25, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && currentStance == BerserkerStance && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(IntimidatingShout) && AggressorsInMelee);
-
-                // if our ObjectManager.GetTarget(ObjectManager.Player) uses melee, but there's a caster attacking us, do not use retaliation
-                TryUseAbility(Retaliation, 0, ObjectManager.Player.IsSpellReady(Retaliation) && !spellcastingAggressors.Any() && currentStance == BattleStance && FacingAllTargets && !ObjectManager.Aggressors.Any(a => a.HasDebuff(IntimidatingShout)));
-            }
-
-            // Use these abilities if you are fighting only one mob at a time, or multiple and one or more are not in melee range.
-            if (ObjectManager.Aggressors.Any() || (ObjectManager.Aggressors.Count() > 1 && !AggressorsInMelee))
-            {
-                TryUseAbility(Slam, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && slamReady, SlamCallback);
-                
-                // TryUseAbility(Rend, 10, (currentStance == BattleStance && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) && (ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Elemental && ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Undead)));
-
-                TryUseAbility(Bloodthirst, 30);
-
-                TryUseAbility(Hamstring, 10, ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Humanoid && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Hamstring));
-
-                TryUseAbility(HeroicStrike, ObjectManager.Player.Level < 30 ? 15 : 45, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
-
-                TryUseAbility(Execute, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20);
-
-                TryUseAbility(SunderArmor, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 80 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SunderArmor));
-            }
-
-            if (overpowerStopwatch.ElapsedMilliseconds > 5000)
-            {
-                overpowerStopwatch.Stop();
-            }
+            ExecuteRotation();
         }
 
         private void OnSlamReadyCallback(object sender, EventArgs e)
@@ -178,7 +118,80 @@ namespace WarriorFury.Tasks
 
         public override void PerformCombatRotation()
         {
-            throw new NotImplementedException();
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                if (ObjectManager.Aggressors.Any())
+                    ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                else
+                    return;
+            }
+
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
+            string currentStance = ObjectManager.Player.CurrentStance;
+            IEnumerable<IWoWUnit> spellcastingAggressors = ObjectManager.Aggressors
+                .Where(a => a.Mana > 0);
+            // Use these abilities when fighting any number of mobs.
+            TryUseAbility(BerserkerStance, condition: ObjectManager.Player.Level >= 30 && currentStance == BattleStance && (ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 80 || ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Elemental || ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Undead));
+
+            TryUseAbility(Pummel, 10, currentStance == BerserkerStance && ObjectManager.GetTarget(ObjectManager.Player).Mana > 0 && (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling));
+
+            // TryUseAbility(Rend, 10, (currentStance == BattleStance && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) && (ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Elemental && ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Undead)));
+
+            TryUseAbility(DeathWish, 10, ObjectManager.Player.IsSpellReady(DeathWish) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
+
+            TryUseAbility(BattleShout, 10, !ObjectManager.Player.HasBuff(BattleShout));
+
+            TryUseAbilityById(BloodFury, 4, 0, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
+
+            TryUseAbility(Bloodrage, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+
+            TryUseAbility(Execute, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20);
+
+            TryUseAbility(BerserkerRage, condition: ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 70 && currentStance == BerserkerStance);
+
+            TryUseAbility(Overpower, 5, currentStance == BattleStance && overpowerStopwatch.IsRunning);
+
+            // Use these abilities if you are fighting TWO OR MORE mobs at once.
+            if (ObjectManager.Aggressors.Count() >= 2)
+            {
+                TryUseAbility(IntimidatingShout, 25, !(ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(IntimidatingShout) || ObjectManager.Player.HasBuff(Retaliation)) && ObjectManager.Aggressors.All(a => a.Position.DistanceTo(ObjectManager.Player.Position) < 10));
+
+                TryUseAbility(DemoralizingShout, 10, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(DemoralizingShout));
+
+                // TryUseAbility(Cleave, 20, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && FacingAllTargets);
+
+                TryUseAbility(Whirlwind, 25, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && currentStance == BerserkerStance && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(IntimidatingShout) && AggressorsInMelee);
+
+                // if our ObjectManager.GetTarget(ObjectManager.Player) uses melee, but there's a caster attacking us, do not use retaliation
+                TryUseAbility(Retaliation, 0, ObjectManager.Player.IsSpellReady(Retaliation) && !spellcastingAggressors.Any() && currentStance == BattleStance && FacingAllTargets && !ObjectManager.Aggressors.Any(a => a.HasDebuff(IntimidatingShout)));
+            }
+
+            // Use these abilities if you are fighting only one mob at a time, or multiple and one or more are not in melee range.
+            if (ObjectManager.Aggressors.Any() || (ObjectManager.Aggressors.Count() > 1 && !AggressorsInMelee))
+            {
+                TryUseAbility(Slam, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && slamReady, SlamCallback);
+
+                // TryUseAbility(Rend, 10, (currentStance == BattleStance && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Rend) && (ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Elemental && ObjectManager.GetTarget(ObjectManager.Player).CreatureType != CreatureType.Undead)));
+
+                TryUseAbility(Bloodthirst, 30);
+
+                TryUseAbility(Hamstring, 10, ObjectManager.GetTarget(ObjectManager.Player).CreatureType == CreatureType.Humanoid && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Hamstring));
+
+                TryUseAbility(HeroicStrike, ObjectManager.Player.Level < 30 ? 15 : 45, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+
+                TryUseAbility(Execute, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20);
+
+                TryUseAbility(SunderArmor, 15, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 80 && !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SunderArmor));
+            }
+
+            if (overpowerStopwatch.ElapsedMilliseconds > 5000)
+            {
+                overpowerStopwatch.Stop();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement safe `PerformCombatRotation` implementations for several PvE rotation tasks

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Cpp.Default.props not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ada83a20c832a90cdfcc6116c14a2