### PR TITLE
Fix spell casting check

### DIFF
--- a/BotProfiles/DruidFeralCombat/Tasks/PvERotationTask.cs
+++ b/BotProfiles/DruidFeralCombat/Tasks/PvERotationTask.cs
@@ -164,7 +164,14 @@ namespace DruidFeral.Tasks
         {
             float distanceToTarget = ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position);
 
-            if (ObjectManager.Player.IsSpellReady(name) && ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(name) && distanceToTarget >= minRange && distanceToTarget <= maxRange && condition && !ObjectManager.Player.IsStunned && ObjectManager.Player.IsCasting && ObjectManager.Player.ChannelingId == 0)
+            if (ObjectManager.Player.IsSpellReady(name) &&
+                ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(name) &&
+                distanceToTarget >= minRange &&
+                distanceToTarget <= maxRange &&
+                condition &&
+                !ObjectManager.Player.IsStunned &&
+                !ObjectManager.Player.IsCasting &&
+                ObjectManager.Player.ChannelingId == 0)
             {
                 ObjectManager.Player.CastSpell(name);
                 callback?.Invoke();


### PR DESCRIPTION
## Summary
- fix `TryCastSpell` in Druid Feral PvE rotation to not cast while already casting

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Cpp.Default.props missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ae47ecb0c832abe1c00051bcd3cb6