### PR TITLE
Implement Druid Restoration tasks

### DIFF
--- a/BotProfiles/DruidRestoration/Tasks/BuffTask.cs
+++ b/BotProfiles/DruidRestoration/Tasks/BuffTask.cs
@@ -1,13 +1,28 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace DruidRestoration.Tasks
 {
+    /// <summary>
+    /// Applies restoration druid buffs when out of combat.
+    /// </summary>
     internal class BuffTask(IBotContext botContext) : BotTask(botContext), IBotTask
     {
         public void Update()
         {
-            BotTasks.Pop();
+            if ((ObjectManager.Player.HasBuff(MarkOfTheWild) || !ObjectManager.Player.IsSpellReady(MarkOfTheWild)) &&
+                (ObjectManager.Player.HasBuff(Thorns) || !ObjectManager.Player.IsSpellReady(Thorns)))
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (!ObjectManager.Player.HasBuff(MarkOfTheWild))
+                ObjectManager.Player.CastSpell(MarkOfTheWild);
+
+            if (!ObjectManager.Player.HasBuff(Thorns))
+                ObjectManager.Player.CastSpell(Thorns);
         }
     }
 }

--- a/BotProfiles/DruidRestoration/Tasks/PullTargetTask.cs
+++ b/BotProfiles/DruidRestoration/Tasks/PullTargetTask.cs
@@ -1,18 +1,55 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using PathfindingService.Models;
+using static BotRunner.Constants.Spellbook;
 
 namespace DruidRestoration.Tasks
 {
+    /// <summary>
+    /// Moves toward and pulls the selected target using Moonfire.
+    /// </summary>
     internal class PullTargetTask : BotTask, IBotTask
     {
-        internal PullTargetTask(IBotContext botContext) : base(botContext)
-        {
+        private const int PullRange = 30;
 
-        }
+        internal PullTargetTask(IBotContext botContext) : base(botContext) { }
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (ObjectManager.GetTarget(ObjectManager.Player).TappedByOther ||
+                (ObjectManager.Aggressors.Any() && !ObjectManager.Aggressors.Any(a => a.Guid == ObjectManager.GetTarget(ObjectManager.Player).Guid)))
+            {
+                ObjectManager.Player.StopAllMovement();
+                Wait.RemoveAll();
+                BotTasks.Pop();
+                return;
+            }
+
+            float distance = ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position);
+            if (distance < PullRange && ObjectManager.Player.IsCasting && ObjectManager.Player.IsSpellReady(Moonfire))
+            {
+                if (ObjectManager.Player.IsMoving)
+                    ObjectManager.Player.StopAllMovement();
+
+                if (Wait.For("RestoDruidPull", 100))
+                {
+                    if (!ObjectManager.Player.IsInCombat)
+                        ObjectManager.Player.CastSpell(Moonfire);
+
+                    if (ObjectManager.Player.IsCasting || ObjectManager.Player.IsInCombat)
+                    {
+                        ObjectManager.Player.StopAllMovement();
+                        Wait.RemoveAll();
+                        BotTasks.Pop();
+                        BotTasks.Push(new PvERotationTask(BotContext));
+                    }
+                }
+                return;
+            }
+
+            Position[] path = Container.PathfindingClient.GetPath(ObjectManager.MapId, ObjectManager.Player.Position, ObjectManager.GetTarget(ObjectManager.Player).Position, true);
+            if (path.Length > 0)
+                ObjectManager.Player.MoveToward(path[0]);
         }
     }
 }

--- a/BotProfiles/DruidRestoration/Tasks/PvERotationTask.cs
+++ b/BotProfiles/DruidRestoration/Tasks/PvERotationTask.cs
@@ -1,14 +1,16 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using static BotRunner.Constants.Spellbook;
 
 namespace DruidRestoration.Tasks
 {
+    /// <summary>
+    /// Basic PvE rotation for a restoration druid.
+    /// Focuses on staying alive while dealing modest damage.
+    /// </summary>
     internal class PvERotationTask : CombatRotationTask, IBotTask
     {
-
         internal PvERotationTask(IBotContext botContext) : base(botContext) { }
-
 
         public void Update()
         {
@@ -20,46 +22,27 @@ namespace DruidRestoration.Tasks
 
             AssignDPSTarget();
 
-            if (ObjectManager.GetTarget(ObjectManager.Player) == null) return;
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null)
+                return;
 
-            //if (Container.State.TankInPosition)
-            //{
-            //    if (MoveTowardsTarget())
-            //        return;
+            if (Update(30))
+                return;
 
-            //    PerformCombatRotation();
-            //}
-            //else if (MoveBehindTankSpot(15))
-            //    return;
-            //else
-            //    ObjectManager.Player.StopAllMovement();
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
             ObjectManager.Player.StopAllMovement();
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
-            ObjectManager.Pet?.Attack();
 
-            TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+            // keep ourselves alive
+            TryCastSpell(Rejuvenation, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 80 && !ObjectManager.Player.HasBuff(Rejuvenation), castOnSelf: true);
+            TryCastSpell(HealingTouch, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 60, castOnSelf: true);
 
-            // if target is low on health, turn off wand and cast drain soul
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
-            {
-                ObjectManager.Player.StopWand();
-                TryCastSpell(DrainSoul, 0, 29);
-            }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
-
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
-
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
-
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
-
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+            // offensive abilities
+            TryCastSpell(Moonfire, 0, 30, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Moonfire));
+            TryCastSpell(Wrath, 0, 30);
         }
     }
 }

--- a/BotProfiles/DruidRestoration/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/DruidRestoration/Tasks/PvPRotationTask.cs
@@ -1,19 +1,43 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace DruidRestoration.Tasks
 {
-    internal class PvPRotationTask : CombatRotationTask, IBotTask
+    /// <summary>
+    /// Basic PvP rotation for a restoration druid. Uses simple heals and damage spells.
+    /// </summary>
+    internal class PvPRotationTask(IBotContext botContext) : CombatRotationTask(botContext), IBotTask
     {
-        internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
-
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            AssignDPSTarget();
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null)
+                return;
+
+            if (Update(30))
+                return;
+
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
 
+            TryCastSpell(Rejuvenation, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 80 && !ObjectManager.Player.HasBuff(Rejuvenation), castOnSelf: true);
+            TryCastSpell(HealingTouch, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 60, castOnSelf: true);
+
+            TryCastSpell(Moonfire, 0, 30, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Moonfire));
+            TryCastSpell(Wrath, 0, 30);
         }
     }
 }

--- a/BotProfiles/DruidRestoration/Tasks/RestTask.cs
+++ b/BotProfiles/DruidRestoration/Tasks/RestTask.cs
@@ -1,13 +1,53 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace DruidRestoration.Tasks
 {
+    /// <summary>
+    /// Handles resting logic for the restoration druid.
+    /// </summary>
     internal class RestTask(IBotContext botContext) : BotTask(botContext), IBotTask
-    {        
+    {
         public void Update()
         {
-            BotTasks.Pop();
-        }        
+            if (ObjectManager.Player.IsCasting)
+                return;
+
+            if (ObjectManager.Player.IsInCombat)
+            {
+                Wait.RemoveAll();
+                ObjectManager.Player.DoEmote(Emote.EMOTE_STATE_STAND);
+                BotTasks.Pop();
+                return;
+            }
+
+            if (HealthOk && ManaOk)
+            {
+                Wait.RemoveAll();
+                ObjectManager.Player.DoEmote(Emote.EMOTE_STATE_STAND);
+                BotTasks.Pop();
+                BotTasks.Push(new BuffTask(BotContext));
+                return;
+            }
+
+            if (ObjectManager.Player.HealthPercent < 60 && Wait.For("HealTouch", 5000, true))
+            {
+                ObjectManager.Player.CastSpell(HealingTouch);
+                return;
+            }
+
+            if (ObjectManager.Player.HealthPercent < 80 && !ObjectManager.Player.HasBuff(Rejuvenation) && Wait.For("Rejuvenation", 5000, true))
+            {
+                ObjectManager.Player.CastSpell(Rejuvenation);
+            }
+        }
+
+        private bool HealthOk => ObjectManager.Player.HealthPercent >= 90;
+
+        private bool ManaOk => (ObjectManager.Player.Level < 6 && ObjectManager.Player.ManaPercent > 50) ||
+                               ObjectManager.Player.ManaPercent >= 90 ||
+                               (ObjectManager.Player.ManaPercent >= 65 && !ObjectManager.Player.IsDrinking);
     }
 }


### PR DESCRIPTION
## Summary
- flesh out Restoration druid profile
- implement BuffTask to apply Mark of the Wild and Thorns
- implement RestTask healing logic with Rejuvenation and Healing Touch
- add Moonfire pull behaviour
- create simple PvE/PvP rotations using healing and damage spells

## Testing
- `dotnet test` *(fails: Aspire workload & Windows targeting not available)*

------
https://chatgpt.com/codex/tasks/task_e_687ae4837bac832a8b05d6633f44a495