### PR TITLE
Add basic Shaman rotations

### DIFF
--- a/BotProfiles/ShamanElemental/Tasks/PvERotationTask.cs
+++ b/BotProfiles/ShamanElemental/Tasks/PvERotationTask.cs
@@ -58,9 +58,20 @@ namespace ShamanElemental.Tasks
         {
             TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting && ObjectManager.GetTarget(ObjectManager.Player).Mana > 0));
 
-            TryCastSpell(EarthShock, 0, 20, !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling || ObjectManager.Player.HasBuff(Clearcasting)));
+            TryCastSpell(EarthShock, 0, 20,
+                !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) &&
+                (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling));
 
-            TryCastSpell(LightningBolt, 0, 30, !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && ObjectManager.Player.ManaPercent > 30 || (ObjectManager.Player.HasBuff(FocusedCasting) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 20 && Wait.For("FocusedLightningBoltDelay", 4000, true)));
+            TryCastSpell(FlameShock, 0, 20,
+                !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(FlameShock) &&
+                !FireImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) &&
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+
+            TryCastSpell(ElementalMastery, 0, int.MaxValue);
+
+            TryCastSpell(LightningBolt, 0, 30,
+                !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) &&
+                (ObjectManager.Player.ManaPercent > 20 || ObjectManager.Player.HasBuff(ElementalMastery)));
 
             TryCastSpell(TremorTotem, 0, int.MaxValue, FearingCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && !ObjectManager.Units.Any(u => u.Position.DistanceTo(ObjectManager.Player.Position) < 29 && u.HealthPercent > 0 && u.Name.Contains(TremorTotem)));
 
@@ -72,7 +83,6 @@ namespace ShamanElemental.Tasks
 
             TryCastSpell(ManaSpringTotem, 0, int.MaxValue, !ObjectManager.Units.Any(u => u.Position.DistanceTo(ObjectManager.Player.Position) < 19 && u.HealthPercent > 0 && u.Name.Contains(ManaSpringTotem)));
 
-            TryCastSpell(FlameShock, 0, 20, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(FlameShock) && (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent >= 50 || NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name)) && !FireImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name));
 
             TryCastSpell(LightningShield, 0, int.MaxValue, !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && !ObjectManager.Player.HasBuff(LightningShield));
 
@@ -80,7 +90,8 @@ namespace ShamanElemental.Tasks
 
             TryCastSpell(FlametongueWeapon, 0, int.MaxValue, ObjectManager.Player.IsSpellReady(FlametongueWeapon) && !ObjectManager.Player.MainhandIsEnchanted && !FireImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name));
 
-            TryCastSpell(ElementalMastery, 0, int.MaxValue);
+            if (ObjectManager.Player.ManaPercent < 5)
+                ObjectManager.Player.StartMeleeAttack();
         }
     }
 }

--- a/BotProfiles/ShamanElemental/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/ShamanElemental/Tasks/PvPRotationTask.cs
@@ -10,11 +10,26 @@ namespace ShamanElemental.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (Update(30))
+                return;
+
+            PerformCombatRotation();
         }
         public override void PerformCombatRotation()
         {
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
 
+            TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting));
+            TryCastSpell(EarthShock, 0, 20, ObjectManager.GetTarget(ObjectManager.Player).IsCasting);
+            TryCastSpell(FlameShock, 0, 20, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(FlameShock));
+            TryCastSpell(LightningBolt, 0, 30, ObjectManager.Player.ManaPercent > 10);
         }
     }
 }

--- a/BotProfiles/ShamanEnhancement/Tasks/PvERotationTask.cs
+++ b/BotProfiles/ShamanEnhancement/Tasks/PvERotationTask.cs
@@ -97,7 +97,10 @@ namespace ShamanEnhancement.Tasks
 
             TryCastSpell(WindfuryWeapon, 0, int.MaxValue, !ObjectManager.Player.MainhandIsEnchanted && ObjectManager.Player.IsSpellReady(WindfuryWeapon));
 
-            //TryCastSpell(StoneclawTotem, 0, int.MaxValue, ObjectManager.Aggressors.Count() > 1);
+            TryCastSpell(StoneclawTotem, 0, int.MaxValue,
+                ObjectManager.Aggressors.Count() > 1 &&
+                !ObjectManager.Units.Any(u => u.Position.DistanceTo(ObjectManager.Player.Position) < 19 &&
+                    u.HealthPercent > 0 && u.Name.Contains(StoneclawTotem)));
 
             TryCastSpell(ManaSpringTotem, 0, int.MaxValue, !ObjectManager.Units.Any(u => u.Position.DistanceTo(ObjectManager.Player.Position) < 19 && u.HealthPercent > 0 && u.Name.Contains(ManaSpringTotem)));
 
@@ -108,6 +111,14 @@ namespace ShamanEnhancement.Tasks
             TryCastSpell(Stormstrike, 0, 5);
 
             TryCastSpell(FlameShock, 0, 20, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(FlameShock) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 70 || NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) && !FireImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name));
+
+            TryCastSpell(EarthShock, 0, 20,
+                !NatureImmuneCreatures.Contains(ObjectManager.GetTarget(ObjectManager.Player).Name) &&
+                (ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling));
+
+            TryUseAbilityById(BloodFury, 4, 0, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 80);
+
+            TryUseAbility(Berserking, 0, ObjectManager.Aggressors.Count() > 1);
 
             //TryCastSpell(EarthShock, 0, 20, !natureImmuneCreatures.Contains(target.Name) && !ObjectManager.Player.IsSpellReady(Stormstrike) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 70 || ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Stormstrike) || ObjectManager.GetTarget(ObjectManager.Player).IsCasting || ObjectManager.GetTarget(ObjectManager.Player).IsChanneling || ObjectManager.Player.HasBuff(Clearcasting));
 

--- a/BotProfiles/ShamanEnhancement/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/ShamanEnhancement/Tasks/PvPRotationTask.cs
@@ -9,10 +9,26 @@ namespace ShamanEnhancement.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (Update(5))
+                return;
+
+            PerformCombatRotation();
         }
         public override void PerformCombatRotation()
         {
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
+            ObjectManager.Player.StartMeleeAttack();
+
+            TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting));
+            TryCastSpell(EarthShock, 0, 20, ObjectManager.GetTarget(ObjectManager.Player).IsCasting);
+            TryCastSpell(Stormstrike, 0, 5);
         }
     }
 }

--- a/BotProfiles/ShamanRestoration/Tasks/PvERotationTask.cs
+++ b/BotProfiles/ShamanRestoration/Tasks/PvERotationTask.cs
@@ -9,10 +9,37 @@ namespace ShamanRestoration.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(12))
+                return;
+
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
+
+            TryCastSpell(HealingWave, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 50, castOnSelf: true);
+
+            TryCastSpell(ManaSpringTotem, 0, int.MaxValue, !ObjectManager.Units.Any(u => u.Position.DistanceTo(ObjectManager.Player.Position) < 19 && u.HealthPercent > 0 && u.Name.Contains(ManaSpringTotem)));
+
+            TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting && ObjectManager.GetTarget(ObjectManager.Player).Mana > 0));
+
+            TryCastSpell(LightningBolt, 0, 30, ObjectManager.Player.ManaPercent > 20);
+
+            TryCastSpell(FlameShock, 0, 20, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(FlameShock));
         }
     }
 }

--- a/BotProfiles/ShamanRestoration/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/ShamanRestoration/Tasks/PvPRotationTask.cs
@@ -10,10 +10,27 @@ namespace ShamanRestoration.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (Update(30))
+                return;
+
+            PerformCombatRotation();
         }
         public override void PerformCombatRotation()
         {
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
+
+            TryCastSpell(HealingWave, 0, int.MaxValue, ObjectManager.Player.HealthPercent < 50, castOnSelf: true);
+
+            TryCastSpell(GroundingTotem, 0, int.MaxValue, ObjectManager.Aggressors.Any(a => a.IsCasting));
+
+            TryCastSpell(LightningBolt, 0, 30, ObjectManager.Player.ManaPercent > 20);
         }
     }
 }


### PR DESCRIPTION
## Summary
- flesh out Enhancement PvE rotation with interrupt logic, totem swap and cooldowns
- expand Elemental PvE rotation and add fallback to melee
- implement simple Restoration PvE rotation
- enable basic PvP combat logic for all Shaman specs

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Cpp.Default.props / Aspire.AppHost.Sdk missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ae27a7850832aa08b69d83dd0cb77