### PR TITLE
Add new warlock spell handling

### DIFF
--- a/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
@@ -54,7 +54,10 @@ namespace WarlockAffliction.Tasks
 
                 TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
+
                 TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+
+                TryCastSpell(Haunt, 0, 30, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Haunt));
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }

--- a/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
@@ -40,6 +40,8 @@ namespace WarlockDemonology.Tasks
 
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
+            TryCastSpell(DemonicEmpowerment, 0, int.MaxValue, ObjectManager.Pet != null && !ObjectManager.Pet.HasBuff(DemonicEmpowerment));
+
             // if target is low on health, turn off wand and cast drain soul
             if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
             {

--- a/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
@@ -53,6 +53,8 @@ namespace WarlockDestruction.Tasks
 
                 TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
+                TryCastSpell(Conflagrate, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate));
+
                 TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
                 TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);

--- a/Exports/GameData.Core/Constants/Spellbook.cs
+++ b/Exports/GameData.Core/Constants/Spellbook.cs
@@ -42,6 +42,9 @@
         public const string LifeTap = "Life Tap";
         public const string ShadowBolt = "Shadow Bolt";
         public const string SiphonLife = "Siphon Life";
+        public const string Haunt = "Haunt";
+        public const string DemonicEmpowerment = "Demonic Empowerment";
+        public const string Conflagrate = "Conflagrate";
         public const string RaptorStrike = "Raptor Strike";
         public const string ArcaneShot = "Arcane Shot";
         public const string SerpentSting = "Serpent Sting";


### PR DESCRIPTION
## Summary
- add new spell constants for warlock specs
- update Affliction PvE rotation to use Haunt
- update Demonology PvE rotation to use Demonic Empowerment
- update Destruction PvE rotation to use Conflagrate

## Testing
- `dotnet test --no-build` *(fails: Could not resolve SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687ae730eebc832a8b95afa2dd506490