### PR TITLE
Improve hunter rotations

### DIFF
--- a/BotProfiles/HunterBeastMastery/Tasks/PvERotationTask.cs
+++ b/BotProfiles/HunterBeastMastery/Tasks/PvERotationTask.cs
@@ -17,7 +17,14 @@ namespace HunterBeastMastery.Tasks
 
         public void Update()
         {
-            if (ObjectManager.Aggressors.Any())
+            // ensure our pet is helping and alive
+            ObjectManager.Pet?.Attack();
+            if (ObjectManager.Pet == null && ObjectManager.Player.IsSpellReady(CallPet))
+                ObjectManager.Player.CastSpell(CallPet);
+            else if (ObjectManager.Pet != null && ObjectManager.Pet.HealthPercent < 40)
+                TryCastSpell(MendPet, castOnSelf: true);
+
+            if (!ObjectManager.Aggressors.Any())
             {
                 BotTasks.Pop();
                 return;
@@ -43,29 +50,26 @@ namespace HunterBeastMastery.Tasks
             {
                 ObjectManager.Player.StartRangedAttack();
             }
-            else if (gun != null && canUseRanged)
+            else if (canUseRanged)
             {
-                //if (!target.HasDebuff(HuntersMark)) 
-                //{
-                //     TryCastSpell(HuntersMark, 0, 34);
-                //}
-                //else 
-                if (!ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SerpentSting))
-                {
+                var target = ObjectManager.GetTarget(ObjectManager.Player);
+                TryCastSpell(HuntersMark, 0, 34, !target.HasDebuff(HuntersMark));
+                TryCastSpell(ConcussiveShot, 0, 34, !target.HasDebuff(ConcussiveShot));
+                if (!target.HasDebuff(SerpentSting))
                     TryCastSpell(SerpentSting, 0, 34);
-                }
+                else if (ObjectManager.Aggressors.Count() > 1)
+                    TryCastSpell(MultiShot, 0, 34);
                 else if (ObjectManager.Player.ManaPercent > 60)
-                {
                     TryCastSpell(ArcaneShot, 0, 34);
-                }
+
+                TryCastSpell(RapidFire, 0, int.MaxValue, target.HealthPercent > 80);
                 return;
-
-
-                //TryCastSpell(ConcussiveShot, 0, 34);
             }
             else
             {
                 // melee rotation
+                TryCastSpell(MongooseBite, 0, 5);
+                TryCastSpell(WingClip, 0, 5, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(WingClip));
                 TryCastSpell(RaptorStrike, 0, 5);
             }
         }

--- a/BotProfiles/HunterBeastMastery/Tasks/RestTask.cs
+++ b/BotProfiles/HunterBeastMastery/Tasks/RestTask.cs
@@ -28,11 +28,20 @@ namespace HunterBeastMastery.Tasks
 
         public void Update()
         {
-            // Check on your pet
-            if (pet != null && !PetHappy && !PetBeingFed)
+            // keep pet summoned and happy
+            if (ObjectManager.Pet == null && ObjectManager.Player.IsSpellReady(CallPet))
+                ObjectManager.Player.CastSpell(CallPet);
+            if (ObjectManager.Pet != null && ObjectManager.Pet.HealthPercent < 40 && ObjectManager.Player.IsSpellReady(MendPet))
+                ObjectManager.Player.CastSpell(MendPet);
+
+            if (pet != null && !PetHappy && !PetBeingFed && petFood != null && ObjectManager.Player.IsSpellReady(FeedPet))
             {
-                
+                ObjectManager.Player.CastSpell(FeedPet);
+                petFood.Use();
             }
+
+            if (ObjectManager.Player.AmmoId != 0 && ObjectManager.GetItemCount(ObjectManager.Player.AmmoId) < 20)
+                ObjectManager.SendChatMessage("Low ammo - consider buying more");
             if (ObjectManager.Player.HealthPercent >= 95 ||
                 ObjectManager.Player.HealthPercent >= 80 && !ObjectManager.Player.IsEating ||
                 ObjectManager.Player.IsInCombat ||

--- a/BotProfiles/HunterMarksmanship/Tasks/PvERotationTask.cs
+++ b/BotProfiles/HunterMarksmanship/Tasks/PvERotationTask.cs
@@ -1,5 +1,8 @@
-﻿using BotRunner.Interfaces;
+﻿using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using GameData.Core.Enums;
+using static BotRunner.Constants.Spellbook;
 
 namespace HunterMarksmanship.Tasks
 {
@@ -10,11 +13,44 @@ namespace HunterMarksmanship.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
-        }
-        public override void PerformCombatRotation()
-        {
+            ObjectManager.Pet?.Attack();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
 
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+
+            if (Update(34))
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+
+            IWoWItem bow = ObjectManager.GetEquippedItem(EquipSlot.Ranged);
+            bool ranged = bow != null && ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position) > 5 &&
+                           ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position) < 34;
+
+            if (ranged)
+            {
+                var target = ObjectManager.GetTarget(ObjectManager.Player);
+                TryCastSpell(HuntersMark, 0, 34, !target.HasDebuff(HuntersMark));
+                TryCastSpell(ConcussiveShot, 0, 34, !target.HasDebuff(ConcussiveShot));
+                if (!target.HasDebuff(SerpentSting))
+                    TryCastSpell(SerpentSting, 0, 34);
+                else if (ObjectManager.Aggressors.Count() > 1)
+                    TryCastSpell(MultiShot, 0, 34);
+                else if (ObjectManager.Player.ManaPercent > 60)
+                    TryCastSpell(ArcaneShot, 0, 34);
+                return;
+            }
+
+            // melee fallback
+            TryCastSpell(MongooseBite, 0, 5);
+            TryCastSpell(WingClip, 0, 5, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(WingClip));
+            TryCastSpell(RaptorStrike, 0, 5);
         }
+        public override void PerformCombatRotation() => Update();
     }
 }

--- a/BotProfiles/HunterMarksmanship/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/HunterMarksmanship/Tasks/PvPRotationTask.cs
@@ -1,5 +1,8 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using GameData.Core.Enums;
+using static BotRunner.Constants.Spellbook;
 
 namespace HunterMarksmanship.Tasks
 {
@@ -7,14 +10,38 @@ namespace HunterMarksmanship.Tasks
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
 
-
         public void Update()
         {
-            BotTasks.Pop();
+            ObjectManager.Pet?.Attack();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
 
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null)
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+
+            if (Update(34))
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+            if (target == null) return;
+
+            bool ranged = ObjectManager.Player.Position.DistanceTo(target.Position) > 5 &&
+                           ObjectManager.Player.Position.DistanceTo(target.Position) < 34;
+            if (ranged)
+            {
+                TryCastSpell(ConcussiveShot, 0, 34, !target.HasDebuff(ConcussiveShot));
+                TryCastSpell(ArcaneShot, 0, 34);
+                return;
+            }
+
+            TryCastSpell(WingClip, 0, 5, !target.HasDebuff(WingClip));
+            TryCastSpell(RaptorStrike, 0, 5);
         }
-        public override void PerformCombatRotation()
-        {
-        }
+
+        public override void PerformCombatRotation() => Update();
     }
 }

--- a/BotProfiles/HunterSurvival/Tasks/PvERotationTask.cs
+++ b/BotProfiles/HunterSurvival/Tasks/PvERotationTask.cs
@@ -1,5 +1,8 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using GameData.Core.Enums;
+using static BotRunner.Constants.Spellbook;
 
 namespace HunterSurvival.Tasks
 {
@@ -9,10 +12,43 @@ namespace HunterSurvival.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            ObjectManager.Pet?.Attack();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+
+            if (Update(34))
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            IWoWItem ranged = ObjectManager.GetEquippedItem(EquipSlot.Ranged);
+            bool canShoot = ranged != null && ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position) > 5 &&
+                             ObjectManager.Player.Position.DistanceTo(ObjectManager.GetTarget(ObjectManager.Player).Position) < 34;
+
+            if (canShoot)
+            {
+                var target = ObjectManager.GetTarget(ObjectManager.Player);
+                TryCastSpell(HuntersMark, 0, 34, !target.HasDebuff(HuntersMark));
+                TryCastSpell(ConcussiveShot, 0, 34, !target.HasDebuff(ConcussiveShot));
+                if (!target.HasDebuff(SerpentSting))
+                    TryCastSpell(SerpentSting, 0, 34);
+                else if (ObjectManager.Aggressors.Count() > 1)
+                    TryCastSpell(MultiShot, 0, 34);
+                else if (ObjectManager.Player.ManaPercent > 60)
+                    TryCastSpell(ArcaneShot, 0, 34);
+                return;
+            }
+
+            TryCastSpell(MongooseBite, 0, 5);
+            TryCastSpell(WingClip, 0, 5, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(WingClip));
+            TryCastSpell(RaptorStrike, 0, 5);
         }
-        public override void PerformCombatRotation()
-        {
-        }
+
+        public override void PerformCombatRotation() => Update();
     }
 }

--- a/BotProfiles/HunterSurvival/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/HunterSurvival/Tasks/PvPRotationTask.cs
@@ -1,5 +1,8 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using GameData.Core.Enums;
+using static BotRunner.Constants.Spellbook;
 
 namespace HunterSurvival.Tasks
 {
@@ -9,11 +12,36 @@ namespace HunterSurvival.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
-        }
-        public override void PerformCombatRotation()
-        {
+            ObjectManager.Pet?.Attack();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
 
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null)
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+
+            if (Update(34))
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+            if (target == null) return;
+
+            bool ranged = ObjectManager.Player.Position.DistanceTo(target.Position) > 5 &&
+                           ObjectManager.Player.Position.DistanceTo(target.Position) < 34;
+            if (ranged)
+            {
+                TryCastSpell(ConcussiveShot, 0, 34, !target.HasDebuff(ConcussiveShot));
+                TryCastSpell(ArcaneShot, 0, 34);
+                return;
+            }
+
+            TryCastSpell(WingClip, 0, 5, !target.HasDebuff(WingClip));
+            TryCastSpell(RaptorStrike, 0, 5);
         }
+
+        public override void PerformCombatRotation() => Update();
     }
 }


### PR DESCRIPTION
## Summary
- flesh out Beast Mastery rotation with pet upkeep, Hunter's Mark, and more abilities
- check ammo and pet happiness while resting
- implement Marksmanship & Survival rotations
- add simple PvP logic for both specs

## Testing
- `dotnet test --no-build` *(fails: Aspire.AppHost.Sdk missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ae28da15c832ab45c936fbbe9816d