### PR TITLE
Add simple paladin rotations

### DIFF
--- a/BotProfiles/PaladinHoly/Tasks/BuffTask.cs
+++ b/BotProfiles/PaladinHoly/Tasks/BuffTask.cs
@@ -1,5 +1,6 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace PaladinHoly.Tasks
 {
@@ -7,7 +8,37 @@ namespace PaladinHoly.Tasks
     {
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Player.IsSpellReady(BlessingOfMight) ||
+                ObjectManager.Player.HasBuff(BlessingOfMight) ||
+                ObjectManager.Player.HasBuff(BlessingOfKings) ||
+                ObjectManager.Player.HasBuff(BlessingOfSanctuary))
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.Player.IsSpellReady(BlessingOfMight) &&
+                !ObjectManager.Player.IsSpellReady(BlessingOfKings) &&
+                !ObjectManager.Player.IsSpellReady(BlessingOfSanctuary))
+                TryCastSpell(BlessingOfMight);
+
+            if (ObjectManager.Player.IsSpellReady(BlessingOfKings) &&
+                !ObjectManager.Player.IsSpellReady(BlessingOfSanctuary))
+                TryCastSpell(BlessingOfKings);
+
+            if (ObjectManager.Player.IsSpellReady(BlessingOfSanctuary))
+                TryCastSpell(BlessingOfSanctuary);
+        }
+
+        private void TryCastSpell(string name)
+        {
+            if (!ObjectManager.Player.HasBuff(name) &&
+                ObjectManager.Player.IsSpellReady(name) &&
+                ObjectManager.Player.Mana > ObjectManager.Player.GetManaCost(name))
+            {
+                ObjectManager.Player.CastSpell(name, castOnSelf: true);
+            }
         }
     }
 }
+

--- a/BotProfiles/PaladinHoly/Tasks/PvERotationTask.cs
+++ b/BotProfiles/PaladinHoly/Tasks/PvERotationTask.cs
@@ -1,5 +1,6 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace PaladinHoly.Tasks
 {
@@ -7,13 +8,45 @@ namespace PaladinHoly.Tasks
     {
         internal PvERotationTask(IBotContext botContext) : base(botContext) { }
 
-
         public void Update()
         {
-            BotTasks.Pop();
+            if (ObjectManager.Player.HealthPercent < 40 &&
+                ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(HolyLight))
+            {
+                ObjectManager.Player.CastSpell(HolyLight, castOnSelf: true);
+                return;
+            }
+
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(3))
+                return;
+
+            ExecuteRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
+            TryCastSpell(DevotionAura, !ObjectManager.Player.HasBuff(DevotionAura));
+            TryCastSpell(SealOfTheCrusader, !ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(HolyLight, ObjectManager.Player.HealthPercent < 60, castOnSelf: true);
         }
     }
 }
+

--- a/BotProfiles/PaladinProtection/PaladinProtection.cs
+++ b/BotProfiles/PaladinProtection/PaladinProtection.cs
@@ -36,6 +36,6 @@ namespace PaladinProtection
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/PaladinProtection/Tasks/PvERotationTask.cs
+++ b/BotProfiles/PaladinProtection/Tasks/PvERotationTask.cs
@@ -1,5 +1,6 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace PaladinProtection.Tasks
 {
@@ -9,12 +10,48 @@ namespace PaladinProtection.Tasks
 
         public override void PerformCombatRotation()
         {
-
+            ExecuteRotation();
         }
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (ObjectManager.Player.HealthPercent < 30 &&
+                ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(HolyLight))
+            {
+                BotTasks.Push(new HealTask(BotContext));
+                return;
+            }
+
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(3))
+                return;
+
+            ExecuteRotation();
+        }
+
+        private void ExecuteRotation()
+        {
+            TryCastSpell(RighteousFury, !ObjectManager.Player.HasBuff(RighteousFury));
+            TryCastSpell(DevotionAura, !ObjectManager.Player.HasBuff(DevotionAura));
+            TryCastSpell(SealOfTheCrusader, !ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(SealOfRighteousness, !ObjectManager.Player.HasBuff(SealOfRighteousness));
+            TryCastSpell(Consecration, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(HolyShield, !ObjectManager.Player.HasBuff(HolyShield));
+            TryCastSpell(DivineProtection, ObjectManager.Player.HealthPercent < 20, castOnSelf: true);
+            TryCastSpell(LayOnHands, ObjectManager.Player.HealthPercent < 10, castOnSelf: true);
         }
     }
 }
+

--- a/BotProfiles/PaladinProtection/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/PaladinProtection/Tasks/PvPRotationTask.cs
@@ -1,5 +1,6 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace PaladinProtection.Tasks
 {
@@ -9,11 +10,36 @@ namespace PaladinProtection.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(3))
+                return;
+
+            ExecuteRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            ExecuteRotation();
+        }
 
+        private void ExecuteRotation()
+        {
+            TryCastSpell(RighteousFury, !ObjectManager.Player.HasBuff(RighteousFury));
+            TryCastSpell(SealOfRighteousness, !ObjectManager.Player.HasBuff(SealOfRighteousness));
+            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfRighteousness));
+            TryCastSpell(HolyShield, !ObjectManager.Player.HasBuff(HolyShield));
         }
     }
 }
+

--- a/BotProfiles/PaladinRetribution/PaladinRetribution.cs
+++ b/BotProfiles/PaladinRetribution/PaladinRetribution.cs
@@ -36,6 +36,6 @@ namespace PaladinRetribution
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/PaladinRetribution/Tasks/PvERotationTask.cs
+++ b/BotProfiles/PaladinRetribution/Tasks/PvERotationTask.cs
@@ -25,7 +25,9 @@ namespace PaladinRetribution.Tasks
 
         public void Update()
         {
-            if (ObjectManager.Player.HealthPercent < 30 && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 && ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(HolyLight))
+            if (ObjectManager.Player.HealthPercent < 30 &&
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50 &&
+                ObjectManager.Player.Mana >= ObjectManager.Player.GetManaCost(HolyLight))
             {
                 BotTasks.Push(new HealTask(BotContext));
                 return;
@@ -70,7 +72,13 @@ namespace PaladinRetribution.Tasks
 
             TryCastSpell(HolyShield, !ObjectManager.Player.HasBuff(HolyShield) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
 
-            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfTheCrusader) || ((ObjectManager.Player.HasBuff(SealOfRighteousness) || ObjectManager.Player.HasBuff(SealOfCommand)) && (ObjectManager.Player.ManaPercent >= 95 || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 3)));
+            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfTheCrusader) ||
+                ((ObjectManager.Player.HasBuff(SealOfRighteousness) || ObjectManager.Player.HasBuff(SealOfCommand)) &&
+                (ObjectManager.Player.ManaPercent >= 95 || ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 3)));
+
+            TryCastSpell(DivineProtection, ObjectManager.Player.HealthPercent < 20, castOnSelf: true);
+            TryCastSpell(LayOnHands, ObjectManager.Player.HealthPercent < 10, castOnSelf: true);
         }
     }
 }
+

--- a/BotProfiles/PaladinRetribution/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/PaladinRetribution/Tasks/PvPRotationTask.cs
@@ -1,5 +1,6 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace PaladinRetribution.Tasks
 {
@@ -7,14 +8,38 @@ namespace PaladinRetribution.Tasks
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
 
-
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(3))
+                return;
+
+            ExecuteRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            ExecuteRotation();
+        }
 
+        private void ExecuteRotation()
+        {
+            TryCastSpell(HammerOfJustice, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent < 20);
+            TryCastSpell(SealOfTheCrusader, !ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(Judgement, ObjectManager.Player.HasBuff(SealOfTheCrusader));
+            TryCastSpell(SealOfRighteousness, !ObjectManager.Player.HasBuff(SealOfRighteousness));
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- wire up PvP rotation creation for Retribution and Protection profiles
- add blessing maintenance for Holy
- implement basic PvE rotation for Holy
- implement PvE and PvP rotations for Protection
- enhance Retribution PvE rotation with defensive spells
- add simple PvP rotation for Retribution

## Testing
- `dotnet test` *(fails: Unable to resolve NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_687ae2a29b84832aa50d85e7f2f8bdaf