### PR TITLE
Add Warlock PvP rotation tasks

### DIFF
--- a/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
@@ -1,4 +1,4 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using static BotRunner.Constants.Spellbook;
 
@@ -7,7 +7,6 @@ namespace WarlockAffliction.Tasks
     internal class PvPRotationTask : CombatRotationTask, IBotTask
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
-
 
         public void Update()
         {
@@ -20,28 +19,24 @@ namespace WarlockAffliction.Tasks
             AssignDPSTarget();
 
             if (ObjectManager.GetTarget(ObjectManager.Player) == null) return;
-
-            //if (Container.State.TankInPosition)
-            //{
-            //    if (MoveTowardsTarget())
-            //        return;
-
-            //    PerformCombatRotation();
-            //}
-            //else if (MoveBehindTankSpot(15))
-            //    return;
-            //else
-            //    ObjectManager.Player.StopAllMovement();
         }
+
         public override void PerformCombatRotation()
         {
             ObjectManager.Player.StopAllMovement();
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
-            TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+            // crowd control / interrupt abilities
+            TryCastSpell(DeathCoil, 0, 20, ObjectManager.GetTarget(ObjectManager.Player).IsCasting);
+            TryCastSpell(Fear, 0, 20,
+                (ObjectManager.GetTarget(ObjectManager.Player).IsCasting ||
+                 ObjectManager.GetTarget(ObjectManager.Player).IsChanneling) &&
+                !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Fear));
 
-            // if target is low on health, turn off wand and cast drain soul
+            TryCastSpell(LifeTap, 0, int.MaxValue,
+                ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+
             if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
@@ -49,15 +44,24 @@ namespace WarlockAffliction.Tasks
             }
             else
             {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
+                TryCastSpell(CurseOfAgony, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Immolate, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Corruption, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+                TryCastSpell(SiphonLife, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
+                TryCastSpell(ShadowBolt, 0, 28,
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
         }
     }

--- a/BotProfiles/WarlockAffliction/WarlockAffliction.cs
+++ b/BotProfiles/WarlockAffliction/WarlockAffliction.cs
@@ -36,6 +36,6 @@ namespace WarlockAffliction
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
@@ -1,4 +1,4 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using static BotRunner.Constants.Spellbook;
 
@@ -10,7 +10,7 @@ namespace WarlockDemonology.Tasks
 
         public void Update()
         {
-            if (ObjectManager.Aggressors.Count() == 0)
+            if (!ObjectManager.Aggressors.Any())
             {
                 BotTasks.Pop();
                 return;
@@ -20,15 +20,26 @@ namespace WarlockDemonology.Tasks
 
             if (ObjectManager.GetTarget(ObjectManager.Player) == null) return;
         }
+
         public override void PerformCombatRotation()
         {
             ObjectManager.Player.StopAllMovement();
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
-            TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+            // crowd control / interrupt abilities
+            TryCastSpell(DeathCoil, 0, 20, ObjectManager.GetTarget(ObjectManager.Player).IsCasting);
+            TryCastSpell(Fear, 0, 20,
+                (ObjectManager.GetTarget(ObjectManager.Player).IsCasting ||
+                 ObjectManager.GetTarget(ObjectManager.Player).IsChanneling) &&
+                !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Fear));
 
-            // if target is low on health, turn off wand and cast drain soul
+            TryCastSpell(LifeTap, 0, int.MaxValue,
+                ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+
+            TryCastSpell(DemonicEmpowerment, 0, int.MaxValue,
+                ObjectManager.Pet != null && !ObjectManager.Pet.HasBuff(DemonicEmpowerment));
+
             if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
@@ -36,15 +47,24 @@ namespace WarlockDemonology.Tasks
             }
             else
             {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
+                TryCastSpell(CurseOfAgony, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Immolate, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Corruption, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+                TryCastSpell(SiphonLife, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
+                TryCastSpell(ShadowBolt, 0, 28,
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
         }
     }

--- a/BotProfiles/WarlockDemonology/WarlockDemonology.cs
+++ b/BotProfiles/WarlockDemonology/WarlockDemonology.cs
@@ -36,6 +36,6 @@ namespace WarlockDemonology
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
@@ -1,11 +1,13 @@
-﻿using BotRunner.Interfaces;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockDestruction.Tasks
 {
-    public class PvPRotationTask(IBotContext botContext) : CombatRotationTask(botContext), IBotTask
+    internal class PvPRotationTask : CombatRotationTask, IBotTask
     {
+        internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -17,28 +19,24 @@ namespace WarlockDestruction.Tasks
             AssignDPSTarget();
 
             if (ObjectManager.GetTarget(ObjectManager.Player) == null) return;
-
-            //if (Container.State.TankInPosition)
-            //{
-            //    if (MoveTowardsTarget())
-            //        return;
-
-            //    PerformCombatRotation();
-            //}
-            //else if (MoveBehindTankSpot(15))
-            //    return;
-            //else
-            //    ObjectManager.Player.StopAllMovement();
         }
+
         public override void PerformCombatRotation()
         {
             ObjectManager.Player.StopAllMovement();
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
-            TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+            // crowd control / interrupt abilities
+            TryCastSpell(DeathCoil, 0, 20, ObjectManager.GetTarget(ObjectManager.Player).IsCasting);
+            TryCastSpell(Fear, 0, 20,
+                (ObjectManager.GetTarget(ObjectManager.Player).IsCasting ||
+                 ObjectManager.GetTarget(ObjectManager.Player).IsChanneling) &&
+                !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Fear));
 
-            // if target is low on health, turn off wand and cast drain soul
+            TryCastSpell(LifeTap, 0, int.MaxValue,
+                ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
+
             if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
@@ -46,15 +44,27 @@ namespace WarlockDestruction.Tasks
             }
             else
             {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
+                TryCastSpell(CurseOfAgony, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Immolate, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+                TryCastSpell(Conflagrate, 0, 28,
+                    ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate));
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+                TryCastSpell(Corruption, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
+                TryCastSpell(SiphonLife, 0, 28,
+                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+
+                TryCastSpell(ShadowBolt, 0, 28,
+                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
         }
     }

--- a/BotProfiles/WarlockDestruction/WarlockDestruction.cs
+++ b/BotProfiles/WarlockDestruction/WarlockDestruction.cs
@@ -36,6 +36,6 @@ namespace WarlockDestruction
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/Exports/GameData.Core/Constants/Spellbook.cs
+++ b/Exports/GameData.Core/Constants/Spellbook.cs
@@ -37,6 +37,7 @@
         public const string Corruption = "Corruption";
         public const string CurseOfAgony = "Curse of Agony";
         public const string DeathCoil = "Death Coil";
+        public const string Fear = "Fear";
         public const string DrainSoul = "Drain Soul";
         public const string Immolate = "Immolate";
         public const string LifeTap = "Life Tap";


### PR DESCRIPTION
## Summary
- add Fear spell constant
- implement PvP rotation tasks for each Warlock spec
- instantiate PvP tasks in each Warlock profile

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Cpp.Default.props missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ccc8e250c832a9d781d4906c49192