### PR TITLE
Improve Warlock pet handling and cooldowns

### DIFF
--- a/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockAffliction.Tasks
@@ -38,6 +40,17 @@ namespace WarlockAffliction.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             // if target is low on health, turn off wand and cast drain soul
@@ -61,6 +74,33 @@ namespace WarlockAffliction.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockAffliction.Tasks
@@ -39,6 +41,17 @@ namespace WarlockAffliction.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             // if target is low on health, turn off wand and cast drain soul
@@ -59,6 +72,33 @@ namespace WarlockAffliction.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockAffliction/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/SummonPetTask.cs
@@ -15,17 +15,35 @@ namespace WarlockAffliction.Tasks
 
             ObjectManager.Player.DoEmote(Emote.EMOTE_STATE_STAND);
 
-            if ((!ObjectManager.Player.IsSpellReady(SummonImp) && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)) || ObjectManager.Pet != null)
+            if ((!ObjectManager.Player.IsSpellReady(SummonImp)
+                && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)
+                && !ObjectManager.Player.IsSpellReady(SummonSuccubus)
+                && !ObjectManager.Player.IsSpellReady(SummonFelhunter)
+                && !ObjectManager.Player.IsSpellReady(SummonFelguard)) || ObjectManager.Pet != null)
             {
                 BotTasks.Pop();
                 BotTasks.Push(new BuffTask(BotContext));
                 return;
             }
 
-            if (ObjectManager.Player.IsSpellReady(SummonImp))
-                ObjectManager.Player.CastSpell(SummonImp);
-            else
-                ObjectManager.Player.CastSpell(SummonVoidwalker);
+            string spellToCast = SummonImp;
+
+            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            {
+                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
+                    spellToCast = SummonVoidwalker;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
+            {
+                spellToCast = SummonSuccubus;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
+            {
+                spellToCast = SummonFelhunter;
+            }
+
+            if (ObjectManager.Player.IsSpellReady(spellToCast))
+                ObjectManager.Player.CastSpell(spellToCast);
         }
     }
 }

--- a/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockDemonology.Tasks
@@ -38,6 +40,17 @@ namespace WarlockDemonology.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             TryCastSpell(DemonicEmpowerment, 0, int.MaxValue, ObjectManager.Pet != null && !ObjectManager.Pet.HasBuff(DemonicEmpowerment));
@@ -60,6 +73,33 @@ namespace WarlockDemonology.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockDemonology.Tasks
@@ -26,6 +28,17 @@ namespace WarlockDemonology.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             // if target is low on health, turn off wand and cast drain soul
@@ -46,6 +59,33 @@ namespace WarlockDemonology.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockDemonology/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/SummonPetTask.cs
@@ -14,17 +14,35 @@ namespace WarlockDemonology.Tasks
 
             ObjectManager.Player.DoEmote(Emote.EMOTE_STATE_STAND);
 
-            if ((!ObjectManager.Player.IsSpellReady(SummonImp) && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)) || ObjectManager.Pet != null)
+            if ((!ObjectManager.Player.IsSpellReady(SummonImp)
+                && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)
+                && !ObjectManager.Player.IsSpellReady(SummonSuccubus)
+                && !ObjectManager.Player.IsSpellReady(SummonFelhunter)
+                && !ObjectManager.Player.IsSpellReady(SummonFelguard)) || ObjectManager.Pet != null)
             {
                 BotTasks.Pop();
                 BotTasks.Push(new BuffTask(BotContext));
                 return;
             }
 
-            if (ObjectManager.Player.IsSpellReady(SummonImp))
-                ObjectManager.Player.CastSpell(SummonImp);
-            else
-                ObjectManager.Player.CastSpell(SummonVoidwalker);
+            string spellToCast = SummonImp;
+
+            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            {
+                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
+                    spellToCast = SummonVoidwalker;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
+            {
+                spellToCast = SummonSuccubus;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
+            {
+                spellToCast = SummonFelhunter;
+            }
+
+            if (ObjectManager.Player.IsSpellReady(spellToCast))
+                ObjectManager.Player.CastSpell(spellToCast);
         }
     }
 }

--- a/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockDestruction.Tasks
@@ -39,6 +41,17 @@ namespace WarlockDestruction.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             // if target is low on health, turn off wand and cast drain soul
@@ -61,6 +74,33 @@ namespace WarlockDestruction.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
 ﻿using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using ForegroundBotRunner.Mem;
+using GameData.Core.Interfaces;
 using static BotRunner.Constants.Spellbook;
 
 namespace WarlockDestruction.Tasks
@@ -36,6 +38,17 @@ namespace WarlockDestruction.Tasks
             ObjectManager.Player.Face(ObjectManager.GetTarget(ObjectManager.Player).Position);
             ObjectManager.Pet?.Attack();
 
+            UseCooldowns();
+
+            if (ObjectManager.Pet != null)
+            {
+                if (ObjectManager.Player.HealthPercent < 40 && ObjectManager.Pet.CanUse(Sacrifice))
+                    ObjectManager.Pet.Cast(Sacrifice);
+
+                if (ObjectManager.Pet.CanUse(Torment))
+                    ObjectManager.Pet.Cast(Torment);
+            }
+
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
             // if target is low on health, turn off wand and cast drain soul
@@ -56,6 +69,33 @@ namespace WarlockDestruction.Tasks
 
                 TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
             }
+        }
+
+        private void UseCooldowns()
+        {
+            var trinket1 = ObjectManager.GetEquippedItem(EquipSlot.Trinket1);
+            var trinket2 = ObjectManager.GetEquippedItem(EquipSlot.Trinket2);
+
+            if (ItemReady(trinket1))
+                trinket1.Use();
+
+            if (ItemReady(trinket2))
+                trinket2.Use();
+
+            if (ObjectManager.Player.IsSpellReady(BloodFury))
+                ObjectManager.Player.CastSpell(BloodFury);
+
+            if (ObjectManager.Player.IsSpellReady(Berserking))
+                ObjectManager.Player.CastSpell(Berserking);
+        }
+
+        private bool ItemReady(IWoWItem? item)
+        {
+            if (item == null)
+                return false;
+
+            var result = Functions.LuaCallWithResult($"startTime, duration, enable = GetItemCooldown({item.ItemId}); {{0}} = duration;");
+            return result.Length > 0 && result[0] == "0";
         }
     }
 }

--- a/BotProfiles/WarlockDestruction/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/SummonPetTask.cs
@@ -14,17 +14,35 @@ namespace WarlockDestruction.Tasks
 
             ObjectManager.Player.DoEmote(Emote.EMOTE_STATE_STAND);
 
-            if ((!ObjectManager.Player.IsSpellReady(SummonImp) && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)) || ObjectManager.Pet != null)
+            if ((!ObjectManager.Player.IsSpellReady(SummonImp)
+                && !ObjectManager.Player.IsSpellReady(SummonVoidwalker)
+                && !ObjectManager.Player.IsSpellReady(SummonSuccubus)
+                && !ObjectManager.Player.IsSpellReady(SummonFelhunter)
+                && !ObjectManager.Player.IsSpellReady(SummonFelguard)) || ObjectManager.Pet != null)
             {
                 BotTasks.Pop();
                 BotTasks.Push(new BuffTask(BotContext));
                 return;
             }
 
-            if (ObjectManager.Player.IsSpellReady(SummonImp))
-                ObjectManager.Player.CastSpell(SummonImp);
-            else
-                ObjectManager.Player.CastSpell(SummonVoidwalker);
+            string spellToCast = SummonImp;
+
+            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            {
+                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
+                    spellToCast = SummonVoidwalker;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
+            {
+                spellToCast = SummonSuccubus;
+            }
+            else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
+            {
+                spellToCast = SummonFelhunter;
+            }
+
+            if (ObjectManager.Player.IsSpellReady(spellToCast))
+                ObjectManager.Player.CastSpell(spellToCast);
         }
     }
 }

--- a/Exports/GameData.Core/Constants/Spellbook.cs
+++ b/Exports/GameData.Core/Constants/Spellbook.cs
@@ -218,6 +218,11 @@
         public const string HealthFunnel = "Health Funnel";
         public const string SummonImp = "Summon Imp";
         public const string SummonVoidwalker = "Summon Voidwalker";
+        public const string SummonSuccubus = "Summon Succubus";
+        public const string SummonFelhunter = "Summon Felhunter";
+        public const string SummonFelguard = "Summon Felguard";
+        public const string Torment = "Torment";
+        public const string Sacrifice = "Sacrifice";
         public const string DemonArmor = "Demon Armor";
         public const string DemonSkin = "Demon Skin";
         public const string MortalStrike = "Mortal Strike";


### PR DESCRIPTION
## Summary
- extend `SummonPetTask` logic to pick demons based on the situation
- add pet ability and additional summon constants
- trigger Voidwalker abilities and use trinkets/racials in warlock rotations

## Testing
- `dotnet test --no-build` *(fails: Microsoft.Cpp.Default.props missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ccc8f694c832a9e1d7528b2cad660