### PR TITLE
Add warrior PvP ability rotations

### DIFF
--- a/BotProfiles/WarriorArms/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarriorArms/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
-﻿using BotRunner.Interfaces;
+﻿using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace WarriorArms.Tasks
 {
@@ -9,10 +11,49 @@ namespace WarriorArms.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(5))
+                return;
+
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+            if (target == null)
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(target.Position);
+            ObjectManager.Player.StartMeleeAttack();
+
+            string stance = ObjectManager.Player.CurrentStance;
+
+            TryCastSpell(BattleStance, 0, int.MaxValue, stance != BattleStance);
+
+            TryUseAbility(BerserkerRage, condition: stance == BerserkerStance);
+
+            TryUseAbility(Pummel, 10, stance == BerserkerStance && target.IsCasting);
+            TryUseAbility(ShieldBash, 10, stance == DefensiveStance && target.IsCasting);
+
+            TryUseAbility(Hamstring, 10, !target.HasDebuff(Hamstring));
+
+            TryUseAbility(IntimidatingShout, 25, ObjectManager.Aggressors.Count() > 1);
+
+            TryUseAbility(MortalStrike, 30);
+            TryUseAbility(Overpower, 5, stance == BattleStance);
         }
     }
 }

--- a/BotProfiles/WarriorFury/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarriorFury/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
-﻿using BotRunner.Interfaces;
+﻿using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace WarriorFury.Tasks
 {
@@ -9,10 +11,49 @@ namespace WarriorFury.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(5))
+                return;
+
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+            if (target == null)
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(target.Position);
+            ObjectManager.Player.StartMeleeAttack();
+
+            string stance = ObjectManager.Player.CurrentStance;
+
+            TryCastSpell(BerserkerStance, 0, int.MaxValue, stance != BerserkerStance);
+
+            TryUseAbility(BerserkerRage, condition: stance == BerserkerStance);
+
+            TryUseAbility(Pummel, 10, stance == BerserkerStance && target.IsCasting);
+
+            TryUseAbility(IntimidatingShout, 25, ObjectManager.Aggressors.Count() > 1);
+
+            TryUseAbility(Hamstring, 10, !target.HasDebuff(Hamstring));
+
+            TryUseAbility(Whirlwind, 25, ObjectManager.Aggressors.Count() > 1 && stance == BerserkerStance);
+            TryUseAbility(Bloodthirst, 30);
+            TryUseAbility(Execute, 15, target.HealthPercent < 20);
         }
     }
 }

--- a/BotProfiles/WarriorProtection/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarriorProtection/Tasks/PvPRotationTask.cs
@@ -1,5 +1,7 @@
-﻿using BotRunner.Interfaces;
+﻿using BotRunner.Constants;
+using BotRunner.Interfaces;
 using BotRunner.Tasks;
+using static BotRunner.Constants.Spellbook;
 
 namespace WarriorProtection.Tasks
 {
@@ -9,10 +11,51 @@ namespace WarriorProtection.Tasks
 
         public void Update()
         {
-            BotTasks.Pop();
+            if (!ObjectManager.Aggressors.Any())
+            {
+                BotTasks.Pop();
+                return;
+            }
+
+            if (ObjectManager.GetTarget(ObjectManager.Player) == null ||
+                ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 0)
+            {
+                ObjectManager.Player.SetTarget(ObjectManager.Aggressors.First().Guid);
+            }
+
+            if (Update(5))
+                return;
+
+            PerformCombatRotation();
         }
+
         public override void PerformCombatRotation()
         {
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+            if (target == null)
+                return;
+
+            ObjectManager.Player.StopAllMovement();
+            ObjectManager.Player.Face(target.Position);
+            ObjectManager.Player.StartMeleeAttack();
+
+            string stance = ObjectManager.Player.CurrentStance;
+
+            TryCastSpell(DefensiveStance, 0, int.MaxValue, stance != DefensiveStance);
+
+            TryUseAbility(BerserkerRage, condition: stance == BerserkerStance);
+
+            TryUseAbility(ShieldBash, 10, target.IsCasting);
+
+            TryUseAbility(ConcussionBlow, 15, !target.IsStunned);
+
+            TryUseAbility(Revenge, 5, stance == DefensiveStance);
+
+            TryUseAbility(ShieldSlam, 20);
+
+            TryUseAbility(Hamstring, 10, !target.HasDebuff(Hamstring));
+
+            TryUseAbility(IntimidatingShout, 25, ObjectManager.Aggressors.Count() > 1);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement PvP rotations for Arms, Fury and Protection warriors
- use interrupts, crowd-control tools and stance logic in combat

## Testing
- `dotnet test --no-build` *(fails: Aspire.AppHost.Sdk missing)*

------
https://chatgpt.com/codex/tasks/task_e_687cce358b18832ab1af789dafc0c07b