### PR TITLE
Fix warrior PvP rotation

### DIFF
--- a/BotProfiles/WarriorArms/WarriorArms.cs
+++ b/BotProfiles/WarriorArms/WarriorArms.cs
@@ -36,6 +36,6 @@ namespace WarriorArms
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/WarriorFury/WarriorFury.cs
+++ b/BotProfiles/WarriorFury/WarriorFury.cs
@@ -36,6 +36,6 @@ namespace WarriorFury
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }

--- a/BotProfiles/WarriorProtection/WarriorProtection.cs
+++ b/BotProfiles/WarriorProtection/WarriorProtection.cs
@@ -36,6 +36,6 @@ namespace WarriorProtection
             new PvERotationTask(botContext);
 
         public IBotTask CreatePvPRotationTask(IBotContext botContext) =>
-            new PvERotationTask(botContext);
+            new PvPRotationTask(botContext);
     }
 }


### PR DESCRIPTION
## Summary
- use `PvPRotationTask` when creating PvP rotation for warrior bots

## Testing
- `dotnet test --no-build` *(fails: missing Visual Studio components and Aspire SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687ce752efe8832aafc1ef8082f040d7