### PR TITLE
Improve Warlock pet summoning logic

### DIFF
--- a/BotProfiles/WarlockAffliction/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/SummonPetTask.cs
@@ -28,19 +28,17 @@ namespace WarlockAffliction.Tasks
 
             string spellToCast = SummonImp;
 
-            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            bool needTankPet = ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50;
+
+            if (needTankPet && ObjectManager.Player.IsSpellReady(SummonVoidwalker) && ObjectManager.Player.IsSpellReady(FelDomination))
             {
-                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
-                    spellToCast = SummonVoidwalker;
+                ObjectManager.Player.CastSpell(FelDomination);
+                spellToCast = SummonVoidwalker;
             }
             else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
-            {
                 spellToCast = SummonSuccubus;
-            }
             else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
-            {
                 spellToCast = SummonFelhunter;
-            }
 
             if (ObjectManager.Player.IsSpellReady(spellToCast))
                 ObjectManager.Player.CastSpell(spellToCast);

--- a/BotProfiles/WarlockDemonology/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/SummonPetTask.cs
@@ -27,19 +27,19 @@ namespace WarlockDemonology.Tasks
 
             string spellToCast = SummonImp;
 
-            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            bool needTankPet = ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50;
+
+            if (needTankPet && ObjectManager.Player.IsSpellReady(SummonVoidwalker) && ObjectManager.Player.IsSpellReady(FelDomination))
             {
-                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
-                    spellToCast = SummonVoidwalker;
+                ObjectManager.Player.CastSpell(FelDomination);
+                spellToCast = SummonVoidwalker;
             }
+            else if (ObjectManager.Player.IsSpellReady(SummonFelguard))
+                spellToCast = SummonFelguard;
             else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
-            {
                 spellToCast = SummonSuccubus;
-            }
             else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
-            {
                 spellToCast = SummonFelhunter;
-            }
 
             if (ObjectManager.Player.IsSpellReady(spellToCast))
                 ObjectManager.Player.CastSpell(spellToCast);

--- a/BotProfiles/WarlockDestruction/Tasks/SummonPetTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/SummonPetTask.cs
@@ -27,19 +27,17 @@ namespace WarlockDestruction.Tasks
 
             string spellToCast = SummonImp;
 
-            if (ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50)
+            bool needTankPet = ObjectManager.Aggressors.Count() > 1 || ObjectManager.Player.HealthPercent < 50;
+
+            if (needTankPet && ObjectManager.Player.IsSpellReady(SummonVoidwalker) && ObjectManager.Player.IsSpellReady(FelDomination))
             {
-                if (ObjectManager.Player.IsSpellReady(SummonVoidwalker))
-                    spellToCast = SummonVoidwalker;
+                ObjectManager.Player.CastSpell(FelDomination);
+                spellToCast = SummonVoidwalker;
             }
             else if (ObjectManager.Player.IsSpellReady(SummonSuccubus))
-            {
                 spellToCast = SummonSuccubus;
-            }
             else if (ObjectManager.Player.IsSpellReady(SummonFelhunter))
-            {
                 spellToCast = SummonFelhunter;
-            }
 
             if (ObjectManager.Player.IsSpellReady(spellToCast))
                 ObjectManager.Player.CastSpell(spellToCast);

--- a/Exports/GameData.Core/Constants/Spellbook.cs
+++ b/Exports/GameData.Core/Constants/Spellbook.cs
@@ -223,6 +223,7 @@
         public const string SummonSuccubus = "Summon Succubus";
         public const string SummonFelhunter = "Summon Felhunter";
         public const string SummonFelguard = "Summon Felguard";
+        public const string FelDomination = "Fel Domination";
         public const string Torment = "Torment";
         public const string Sacrifice = "Sacrifice";
         public const string DemonArmor = "Demon Armor";


### PR DESCRIPTION
## Summary
- refine the demon selection logic to pick pets based on context
- prefer Felguard when available for Demonology
- tank with Voidwalker when needed
- only summon Voidwalker instantly via Fel Domination

## Testing
- `dotnet test WestworldOfWarcraft.sln --no-build` *(fails: Microsoft.Cpp.Default.props missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ce9cd09ec832ab323fe282487b904