### PR TITLE
Improve Warlock rotation logic

### DIFF
--- a/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvERotationTask.cs
@@ -10,6 +10,33 @@ namespace WarlockAffliction.Tasks
     {
         internal PvERotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3 &&
+            GetDebuffRemaining(Haunt) > 3;
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -53,27 +80,28 @@ namespace WarlockAffliction.Tasks
 
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
             // if target is low on health, turn off wand and cast drain soul
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28, ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Immolate, 0, 28, ShouldReapply(Immolate) && target.HealthPercent > 30);
 
+            TryCastSpell(Corruption, 0, 28, ShouldReapply(Corruption) && target.HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(SiphonLife, 0, 28, ShouldReapply(SiphonLife) && target.HealthPercent > 50);
 
-                TryCastSpell(Haunt, 0, 30, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Haunt));
+            TryCastSpell(Haunt, 0, 30, ShouldReapply(Haunt));
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+            if (AllDotsActive())
+                TryCastSpell(ShadowBolt, 0, 28, target.HealthPercent > 40);
         }
 
         private void UseCooldowns()

--- a/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockAffliction/Tasks/PvPRotationTask.cs
@@ -10,6 +10,32 @@ namespace WarlockAffliction.Tasks
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3;
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -54,32 +80,30 @@ namespace WarlockAffliction.Tasks
                 ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
 
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28,
+                ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Corruption, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Immolate, 0, 28,
+                ShouldReapply(Immolate) && target.HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(Corruption, 0, 28,
+                ShouldReapply(Corruption) && target.HealthPercent > 30);
 
+            TryCastSpell(SiphonLife, 0, 28,
+                ShouldReapply(SiphonLife) && target.HealthPercent > 50);
+
+            if (AllDotsActive())
                 TryCastSpell(ShadowBolt, 0, 28,
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+                    target.HealthPercent > 40);
         }
 
         private void UseCooldowns()

--- a/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvERotationTask.cs
@@ -10,6 +10,32 @@ namespace WarlockDemonology.Tasks
     {
         internal PvERotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3;
+
         public void Update()
         {
             if (ObjectManager.Aggressors.Count() == 0)
@@ -55,24 +81,26 @@ namespace WarlockDemonology.Tasks
 
             TryCastSpell(DemonicEmpowerment, 0, int.MaxValue, ObjectManager.Pet != null && !ObjectManager.Pet.HasBuff(DemonicEmpowerment));
 
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
             // if target is low on health, turn off wand and cast drain soul
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28, ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Immolate, 0, 28, ShouldReapply(Immolate) && target.HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(Corruption, 0, 28, ShouldReapply(Corruption) && target.HealthPercent > 30);
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+            TryCastSpell(SiphonLife, 0, 28, ShouldReapply(SiphonLife) && target.HealthPercent > 50);
+
+            if (AllDotsActive())
+                TryCastSpell(ShadowBolt, 0, 28, target.HealthPercent > 40);
         }
 
         private void UseCooldowns()

--- a/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDemonology/Tasks/PvPRotationTask.cs
@@ -10,6 +10,32 @@ namespace WarlockDemonology.Tasks
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3;
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -56,32 +82,30 @@ namespace WarlockDemonology.Tasks
                 ObjectManager.Pet != null && !ObjectManager.Pet.HasBuff(DemonicEmpowerment));
 
 
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28,
+                ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Corruption, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Immolate, 0, 28,
+                ShouldReapply(Immolate) && target.HealthPercent > 30);
 
-                TryCastSpell(SiphonLife, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(Corruption, 0, 28,
+                ShouldReapply(Corruption) && target.HealthPercent > 30);
 
+            TryCastSpell(SiphonLife, 0, 28,
+                ShouldReapply(SiphonLife) && target.HealthPercent > 50);
+
+            if (AllDotsActive())
                 TryCastSpell(ShadowBolt, 0, 28,
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+                    target.HealthPercent > 40);
         }
 
         private void UseCooldowns()

--- a/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvERotationTask.cs
@@ -11,6 +11,32 @@ namespace WarlockDestruction.Tasks
 
         internal PvERotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3;
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -54,26 +80,28 @@ namespace WarlockDestruction.Tasks
 
             TryCastSpell(LifeTap, 0, int.MaxValue, ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
             // if target is low on health, turn off wand and cast drain soul
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28, ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Conflagrate, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate));
+            TryCastSpell(Immolate, 0, 28, ShouldReapply(Immolate) && target.HealthPercent > 30);
 
-                TryCastSpell(Corruption, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Conflagrate, 0, 28, GetDebuffRemaining(Immolate) > 3);
 
-                TryCastSpell(SiphonLife, 0, 28, !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) && ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(Corruption, 0, 28, ShouldReapply(Corruption) && target.HealthPercent > 30);
 
-                TryCastSpell(ShadowBolt, 0, 28, ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+            TryCastSpell(SiphonLife, 0, 28, ShouldReapply(SiphonLife) && target.HealthPercent > 50);
+
+            if (AllDotsActive())
+                TryCastSpell(ShadowBolt, 0, 28, target.HealthPercent > 40);
         }
 
         private void UseCooldowns()

--- a/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
+++ b/BotProfiles/WarlockDestruction/Tasks/PvPRotationTask.cs
@@ -10,6 +10,32 @@ namespace WarlockDestruction.Tasks
     {
         internal PvPRotationTask(IBotContext botContext) : base(botContext) { }
 
+        private double GetDebuffRemaining(string debuff)
+        {
+            var result = Functions.LuaCallWithResult(
+                $"local _,_,_,_,_,expires = UnitDebuff('target','{debuff}'); if expires then {{0}} = expires - GetTime() else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private double GetCastTime(string spell)
+        {
+            var result = Functions.LuaCallWithResult($"local _,_,_,castTime = GetSpellInfo('{spell}'); if castTime then {{0}} = castTime / 1000 else {{0}} = 0 end");
+            return result.Length > 0 && double.TryParse(result[0], System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : 0;
+        }
+
+        private bool ShouldReapply(string debuff, double threshold = 3)
+        {
+            var castTime = GetCastTime(debuff);
+            return !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(debuff) ||
+                   GetDebuffRemaining(debuff) < threshold + castTime;
+        }
+
+        private bool AllDotsActive() =>
+            GetDebuffRemaining(CurseOfAgony) > 3 &&
+            GetDebuffRemaining(Immolate) > 3 &&
+            GetDebuffRemaining(Corruption) > 3 &&
+            GetDebuffRemaining(SiphonLife) > 3;
+
         public void Update()
         {
             if (!ObjectManager.Aggressors.Any())
@@ -53,35 +79,33 @@ namespace WarlockDestruction.Tasks
             TryCastSpell(LifeTap, 0, int.MaxValue,
                 ObjectManager.Player.HealthPercent > 85 && ObjectManager.Player.ManaPercent < 80);
 
-            if (ObjectManager.GetTarget(ObjectManager.Player).HealthPercent <= 20)
+            var target = ObjectManager.GetTarget(ObjectManager.Player);
+
+            if (target.HealthPercent <= 20)
             {
                 ObjectManager.Player.StopWand();
                 TryCastSpell(DrainSoul, 0, 29);
+                return;
             }
-            else
-            {
-                TryCastSpell(CurseOfAgony, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(CurseOfAgony) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 90);
 
-                TryCastSpell(Immolate, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(CurseOfAgony, 0, 28,
+                ShouldReapply(CurseOfAgony) && target.HealthPercent > 90);
 
-                TryCastSpell(Conflagrate, 0, 28,
-                    ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Immolate));
+            TryCastSpell(Immolate, 0, 28,
+                ShouldReapply(Immolate) && target.HealthPercent > 30);
 
-                TryCastSpell(Corruption, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(Corruption) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 30);
+            TryCastSpell(Conflagrate, 0, 28,
+                GetDebuffRemaining(Immolate) > 3);
 
-                TryCastSpell(SiphonLife, 0, 28,
-                    !ObjectManager.GetTarget(ObjectManager.Player).HasDebuff(SiphonLife) &&
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 50);
+            TryCastSpell(Corruption, 0, 28,
+                ShouldReapply(Corruption) && target.HealthPercent > 30);
 
+            TryCastSpell(SiphonLife, 0, 28,
+                ShouldReapply(SiphonLife) && target.HealthPercent > 50);
+
+            if (AllDotsActive())
                 TryCastSpell(ShadowBolt, 0, 28,
-                    ObjectManager.GetTarget(ObjectManager.Player).HealthPercent > 40);
-            }
+                    target.HealthPercent > 40);
         }
 
         private void UseCooldowns()


### PR DESCRIPTION
## Summary
- add cast time awareness when checking debuff durations
- maintain previous debuff-tracking helpers
- reapply DoTs only when their remaining duration is less than cast time threshold

## Testing
- `dotnet test` *(fails: missing workloads)*

------
https://chatgpt.com/codex/tasks/task_e_687ced15ce4c832abe42313f9ddd3ba1