### PR TITLE
Use logging instead of Console.WriteLine

### DIFF
--- a/BotProfiles/RogueAssassin/Tasks/PullTargetTask.cs
+++ b/BotProfiles/RogueAssassin/Tasks/PullTargetTask.cs
@@ -2,6 +2,7 @@
 using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using PathfindingService.Models;
+using Serilog;
 using static BotRunner.Constants.Spellbook;
 
 namespace RogueAssassin.Tasks
@@ -34,10 +35,10 @@ namespace RogueAssassin.Tasks
             IWoWItem OffHand = ObjectManager.GetEquippedItem(EquipSlot.OffHand);
             IWoWItem SwapSlotWeap = ObjectManager.GetItem(4, 1);
 
-            //Console.WriteLineVerbose("Mainhand Item Type:  " + MainHand.Info.ItemSubclass);
-            //Console.WriteLineVerbose("Offhand Item Type:  " + OffHand.Info.ItemSubclass);
-            //Console.WriteLineVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.ItemSubclass);
-            //Console.WriteLineVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.Name);
+            //Log.InformationVerbose("Mainhand Item Type:  " + MainHand.Info.ItemSubclass);
+            //Log.InformationVerbose("Offhand Item Type:  " + OffHand.Info.ItemSubclass);
+            //Log.InformationVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.ItemSubclass);
+            //Log.InformationVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.Name);
 
             // Check to see if a Dagger is Equipped in the mainhand
 
@@ -79,7 +80,7 @@ namespace RogueAssassin.Tasks
             // if (SwapMaceOrSwordReady == true)
             // {
             //    Functions.LuaCall($"UseContainerItem({4}, {2})");
-            //    Console.WriteLineVerbose(MainHand.Info.Name + "Swapped Into Mainhand!");
+            //    Log.InformationVerbose(MainHand.Info.Name + "Swapped Into Mainhand!");
             //}
 
             // If Swap dagger is ready and the playe is not in combat, swap to a mainhand dagger.
@@ -87,7 +88,7 @@ namespace RogueAssassin.Tasks
             if (SwapDaggerReady == true && !ObjectManager.Player.IsInCombat && !ObjectManager.Player.HasBuff(Stealth))
             {
                 ObjectManager.UseContainerItem(4, 2);
-                Console.WriteLine(MainHand.Info.Name + " swapped Into Mainhand!");
+                Log.Information(MainHand.Info.Name + " swapped Into Mainhand!");
             }
 
 

--- a/BotProfiles/RogueAssassin/Tasks/PvERotationTask.cs
+++ b/BotProfiles/RogueAssassin/Tasks/PvERotationTask.cs
@@ -2,6 +2,7 @@
 using BotRunner.Interfaces;
 using BotRunner.Tasks;
 using static BotRunner.Constants.Spellbook;
+using Serilog;
 
 namespace RogueAssassin.Tasks
 {
@@ -48,10 +49,10 @@ namespace RogueAssassin.Tasks
                 IWoWItem OffHand = ObjectManager.GetEquippedItem(EquipSlot.OffHand);
                 IWoWItem SwapSlotWeap = ObjectManager.GetItem(4, 1);
 
-                //Console.WriteLineVerbose("Mainhand Item Type:  " + MainHand.Info.ItemSubclass);
-                //Console.WriteLineVerbose("Offhand Item Type:  " + OffHand.Info.ItemSubclass);
-                //Console.WriteLineVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.ItemSubclass);
-                //Console.WriteLineVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.Name);
+                //Log.InformationVerbose("Mainhand Item Type:  " + MainHand.Info.ItemSubclass);
+                //Log.InformationVerbose("Offhand Item Type:  " + OffHand.Info.ItemSubclass);
+                //Log.InformationVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.ItemSubclass);
+                //Log.InformationVerbose("Swap Weapon Item Type:  " + SwapSlotWeap.Info.Name);
 
                 // Check to see if a Dagger is Equipped in the mainhand
 
@@ -93,7 +94,7 @@ namespace RogueAssassin.Tasks
                 if (SwapMaceOrSwordReady == true)
                 {
                     ObjectManager.UseContainerItem(4, 21);
-                    Console.WriteLine(MainHand.Info.Name + "Swapped Into Mainhand!");
+                    Log.Information(MainHand.Info.Name + "Swapped Into Mainhand!");
                 }
 
             // set secondaryTarget

--- a/Exports/BotRunner/BotRunnerService.cs
+++ b/Exports/BotRunner/BotRunnerService.cs
@@ -3,6 +3,7 @@ using Communication;
 using GameData.Core.Enums;
 using GameData.Core.Interfaces;
 using GameData.Core.Models;
+using Serilog;
 using Xas.FluentBehaviourTree;
 
 namespace BotRunner
@@ -137,7 +138,7 @@ namespace BotRunner
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[BOT RUNNER] {ex}");
+                    Log.Error($"[BOT RUNNER] {ex}");
                 }
             }
         }

--- a/Exports/WoWSharpClient/Client/AuthLoginClient.cs
+++ b/Exports/WoWSharpClient/Client/AuthLoginClient.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using WowSrp.Client;
+using Serilog;
 
 namespace WoWSharpClient.Client
 {
@@ -39,7 +40,7 @@ namespace WoWSharpClient.Client
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[LoginClient] {ex}");
+                Log.Error($"[LoginClient] {ex}");
             }
         }
 
@@ -75,7 +76,7 @@ namespace WoWSharpClient.Client
             writer.Flush();
             byte[] packetData = memoryStream.ToArray();
 
-            Console.WriteLine($"[AuthLoginClient] -> CMD_AUTH_LOGON_CHALLENGE [{packetData.Length}]");
+            Log.Information($"[AuthLoginClient] -> CMD_AUTH_LOGON_CHALLENGE [{packetData.Length}]");
 
             WoWSharpEventEmitter.Instance.FireOnHandshakeBegin();
             _stream.Write(packetData, 0, packetData.Length);
@@ -90,7 +91,7 @@ namespace WoWSharpClient.Client
                 using var reader = new BinaryReader(_stream, Encoding.UTF8, true);
                 byte[] packet = reader.ReadBytes(119); // Adjust length if necessary
 
-                Console.WriteLine($"[AuthLoginClient] <- CMD_AUTH_LOGON_CHALLENGE [{packet.Length}]");
+                Log.Information($"[AuthLoginClient] <- CMD_AUTH_LOGON_CHALLENGE [{packet.Length}]");
 
                 byte opcode = packet[0];
                 ResponseCode result = (ResponseCode)packet[2];
@@ -114,12 +115,12 @@ namespace WoWSharpClient.Client
                 }
                 else
                 {
-                    Console.WriteLine($"[AuthLoginClient] Unexpected AUTH_CHALLENGE response: opcode {opcode:X2}, result {result}");
+                    Log.Error($"[AuthLoginClient] Unexpected AUTH_CHALLENGE response: opcode {opcode:X2}, result {result}");
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[AuthLoginClient] Error in ReceiveAuthLogonChallengeServer: {ex}");
+                Log.Error($"[AuthLoginClient] Error in ReceiveAuthLogonChallengeServer: {ex}");
             }
         }
 
@@ -144,14 +145,14 @@ namespace WoWSharpClient.Client
                 writer.Flush();
                 byte[] packetData = memoryStream.ToArray();
 
-                Console.WriteLine($"[AuthLoginClient] -> CMD_AUTH_LOGON_PROOF [{packetData.Length}]");
+                Log.Information($"[AuthLoginClient] -> CMD_AUTH_LOGON_PROOF [{packetData.Length}]");
 
                 _stream.Write(packetData, 0, packetData.Length);
                 ReceiveAuthProofLogonResponse();
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[LoginClient] Error in SendLogonProof: {ex}");
+                Log.Error($"[LoginClient] Error in SendLogonProof: {ex}");
             }
         }
 
@@ -162,7 +163,7 @@ namespace WoWSharpClient.Client
                 using var reader = new BinaryReader(_stream, Encoding.UTF8, true);
                 byte[] header = reader.ReadBytes(2);
 
-                Console.WriteLine($"[AuthLoginClient] <- CMD_AUTH_LOGON_PROOF [{header.Length}]");
+                Log.Information($"[AuthLoginClient] <- CMD_AUTH_LOGON_PROOF [{header.Length}]");
 
                 if (header.Length < 2)
                     return;
@@ -188,13 +189,13 @@ namespace WoWSharpClient.Client
                 }
                 else
                 {
-                    Console.WriteLine($"[AuthLoginClient] Failed AUTH_PROOF response: opcode {opcode:X2}, result {result}");
+                    Log.Error($"[AuthLoginClient] Failed AUTH_PROOF response: opcode {opcode:X2}, result {result}");
                     WoWSharpEventEmitter.Instance.FireOnLoginFailure();
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[AuthLoginClient] Error in ReceiveAuthProofLogonResponse: {ex}");
+                Log.Error($"[AuthLoginClient] Error in ReceiveAuthProofLogonResponse: {ex}");
                 WoWSharpEventEmitter.Instance.FireOnLoginFailure();
             }
         }
@@ -212,13 +213,13 @@ namespace WoWSharpClient.Client
                 writer.Flush();
                 byte[] packetData = memoryStream.ToArray();
 
-                Console.WriteLine($"[AuthLoginClient] -> CMD_REALM_LIST ({packetData.Length} bytes)");
+                Log.Information($"[AuthLoginClient] -> CMD_REALM_LIST ({packetData.Length} bytes)");
 
                 _stream.Write(packetData, 0, packetData.Length);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[LoginClient] Error in SendRealmListRequest: {ex}");
+                Log.Error($"[LoginClient] Error in SendRealmListRequest: {ex}");
             }
         }
 
@@ -262,12 +263,12 @@ namespace WoWSharpClient.Client
                 }
                 else
                 {
-                    //Console.WriteLine("[LoginClient] Unexpected opcode received in REALM_LIST response.");
+                    //Log.Error("[LoginClient Unexpected opcode received in REALM_LIST response.");
                 }
             }
             catch (Exception ex)
             {
-                //Console.WriteLine($"[LoginClient] An error occurred while receiving REALM_LIST response: {ex}");
+                //Log.Information($"[LoginClient] An error occurred while receiving REALM_LIST response: {ex}");
             }
 
             return list;

--- a/Exports/WoWSharpClient/Client/WoWClient.cs
+++ b/Exports/WoWSharpClient/Client/WoWClient.cs
@@ -1,6 +1,7 @@
 ﻿using GameData.Core.Enums;
 using GameData.Core.Models;
 using System.Net;
+using Serilog;
 
 namespace WoWSharpClient.Client
 {
@@ -40,7 +41,7 @@ namespace WoWSharpClient.Client
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Exception occured during login: {ex}");
+                Log.Error($"Exception occured during login: {ex}");
                 _isLoggedIn = false;
             }
             _isLoggedIn = true;

--- a/Exports/WoWSharpClient/Client/WorldClient.cs
+++ b/Exports/WoWSharpClient/Client/WorldClient.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using WowSrp.Header;
+using Serilog;
 
 namespace WoWSharpClient.Client
 {
@@ -53,7 +54,7 @@ namespace WoWSharpClient.Client
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.Error(ex);
             }
         }
 
@@ -64,7 +65,7 @@ namespace WoWSharpClient.Client
 
             if (header.Length < 4)
             {
-                Console.WriteLine($"[WorldClient] Received incomplete SMSG_AUTH_CHALLENGE header.");
+                Log.Error($"[WorldClient] Received incomplete SMSG_AUTH_CHALLENGE header.");
                 return;
             }
 
@@ -74,7 +75,7 @@ namespace WoWSharpClient.Client
             byte[] serverSeed = reader.ReadBytes(size - sizeof(ushort));
             if (serverSeed.Length < 4)
             {
-                Console.WriteLine($"[WorldClient] Incomplete SMSG_AUTH_CHALLENGE packet.");
+                Log.Error($"[WorldClient] Incomplete SMSG_AUTH_CHALLENGE packet.");
                 return;
             }
 
@@ -85,7 +86,7 @@ namespace WoWSharpClient.Client
         {
             EnqueueSend(async () =>
             {
-                Console.WriteLine($"[WorldClient] Sending packet: {opcode} ({packetData.Length} bytes)");
+                Log.Information( Sending packet: {opcode} ({packetData.Length} bytes)");
                 await _stream.WriteAsync(packetData);
             });
         }
@@ -128,7 +129,7 @@ namespace WoWSharpClient.Client
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[WorldClient] An error occurred while sending CMSG_AUTH_SESSION: {ex}");
+                Log.Error($"[WorldClient] An error occurred while sending CMSG_AUTH_SESSION: {ex}");
             }
         }
 
@@ -231,7 +232,7 @@ namespace WoWSharpClient.Client
 
         public void SendMSGMove(Opcode opcode, byte[] movementInfo)
         {
-            //Console.WriteLine($"[SendMSGMove] {opcode} {BitConverter.ToString(movementInfo)}");
+            //Log.Error($"[SendMSGMove] {opcode} {BitConverter.ToString(movementInfo)}");
             using var ms = new MemoryStream();
             using var writer = new BinaryWriter(ms);
             var header = _vanillaEncryption.CreateClientHeader((uint)(4 + movementInfo.Length), (uint)opcode);
@@ -294,7 +295,7 @@ namespace WoWSharpClient.Client
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[WorldClient][HandleNetworkMessages] An error occurred while handling network messages: {ex} {BitConverter.ToString(body)}");
+                    Log.Error($"[WorldClient][HandleNetworkMessages] An error occurred while handling network messages: {ex} {BitConverter.ToString(body)}");
                 }
             }
             await Task.Delay(10);
@@ -320,7 +321,7 @@ namespace WoWSharpClient.Client
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("[WorldClient] Error during send: " + ex);
+                    Log.Error("[WorldClient] Error during send: " + ex);
                 }
                 finally
                 {

--- a/Exports/WoWSharpClient/Handlers/AccountDataHandler.cs
+++ b/Exports/WoWSharpClient/Handlers/AccountDataHandler.cs
@@ -1,5 +1,6 @@
 ﻿using GameData.Core.Enums;
 using System.Text;
+using Serilog;
 
 namespace WoWSharpClient.Handlers
 {
@@ -18,7 +19,7 @@ namespace WoWSharpClient.Handlers
                     HandleUpdateAccountData(data);
                     break;
                 default:
-                    Console.WriteLine($"Unhandled AccountData opcode: {opcode}");
+                    Log.Error($"Unhandled AccountData opcode: {opcode}");
                     break;
             }
         }
@@ -27,7 +28,7 @@ namespace WoWSharpClient.Handlers
         {
             if (data.Length < 36)
             {
-                Console.WriteLine("Invalid SMSG_ACCOUNT_DATA_TIMES packet size.");
+                Log.Error("Invalid SMSG_ACCOUNT_DATA_TIMES packet size.");
                 return;
             }
 
@@ -39,7 +40,7 @@ namespace WoWSharpClient.Handlers
 
             for (int i = 0; i < 8; i++)
             {
-                //Console.WriteLine($"[AccountDataTimes] Type {i}: Timestamp = {_accountDataTimestamps[i]}");
+                //Log.Error($"[AccountDataTimes] Type {i}: Timestamp = {_accountDataTimestamps[i]}");
             }
 
             //_woWSharpEventEmitter.Emit("AccountDataTimesReceived", _accountDataTimestamps);
@@ -49,7 +50,7 @@ namespace WoWSharpClient.Handlers
         {
             if (data.Length < 16)
             {
-                Console.WriteLine("Invalid SMSG_UPDATE_ACCOUNT_DATA packet size.");
+                Log.Error("Invalid SMSG_UPDATE_ACCOUNT_DATA packet size.");
                 return;
             }
 
@@ -60,7 +61,7 @@ namespace WoWSharpClient.Handlers
 
             if (data.Length < 16 + size)
             {
-                Console.WriteLine($"SMSG_UPDATE_ACCOUNT_DATA: Declared size {size} exceeds actual packet size.");
+                Log.Error($"SMSG_UPDATE_ACCOUNT_DATA: Declared size {size} exceeds actual packet size.");
                 return;
             }
 

--- a/Exports/WoWSharpClient/Handlers/ChatHandler.cs
+++ b/Exports/WoWSharpClient/Handlers/ChatHandler.cs
@@ -1,5 +1,6 @@
 ﻿using GameData.Core.Enums;
 using WoWSharpClient.Utils;
+using Serilog;
 
 namespace WoWSharpClient.Handlers
 {
@@ -81,7 +82,7 @@ namespace WoWSharpClient.Handlers
             }
             catch (EndOfStreamException e)
             {
-                Console.WriteLine($"Error reading chat message: {e.Message}");
+                Log.Error($"Error reading chat message: {e.Message}");
             }
         }
     }

--- a/Exports/WoWSharpClient/Handlers/LoginHandler.cs
+++ b/Exports/WoWSharpClient/Handlers/LoginHandler.cs
@@ -1,5 +1,6 @@
 ﻿using GameData.Core.Enums;
 using GameData.Core.Interfaces;
+using Serilog;
 
 namespace WoWSharpClient.Handlers
 {
@@ -43,11 +44,11 @@ namespace WoWSharpClient.Handlers
             }
             catch (EndOfStreamException e)
             {
-                Console.WriteLine($"Error reading login verify world packet: {e.Message}");
+                Log.Error($"Error reading login verify world packet: {e.Message}");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Unexpected error: {ex.Message}");
+                Log.Error($"Unexpected error: {ex.Message}");
             }
         }
         public static void HandleSetTimeSpeed(Opcode opcode, byte[] data)
@@ -72,11 +73,11 @@ namespace WoWSharpClient.Handlers
             }
             catch (EndOfStreamException e)
             {
-                Console.WriteLine($"Error reading login verify world packet: {e.Message}");
+                Log.Error($"Error reading login verify world packet: {e.Message}");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Unexpected error: {ex.Message}");
+                Log.Error($"Unexpected error: {ex.Message}");
             }
         }
         public static void HandleTimeQueryResponse(Opcode opcode, byte[] data)
@@ -92,17 +93,17 @@ namespace WoWSharpClient.Handlers
 
                 // Read MapId (4 bytes)
                 uint serverTime = reader.ReadUInt32();
-                Console.WriteLine($"[LoginHandler] SMSG_QUERY_TIME_RESPONSE {serverTime}");
+                Log.Error($"[LoginHandler] SMSG_QUERY_TIME_RESPONSE {serverTime}");
                 // Process the login verification as needed
                 //_woWSharpEventEmitter.FireOnSetTimeSpeed(new OnSetTimeSpeedArgs(serverTime, timescale));
             }
             catch (EndOfStreamException e)
             {
-                Console.WriteLine($"Error reading login verify world packet: {e.Message}");
+                Log.Error($"Error reading login verify world packet: {e.Message}");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Unexpected error: {ex.Message}");
+                Log.Error($"Unexpected error: {ex.Message}");
             }
         }
     }

--- a/Exports/WoWSharpClient/Handlers/MovementHandler.cs
+++ b/Exports/WoWSharpClient/Handlers/MovementHandler.cs
@@ -4,6 +4,7 @@ using GameData.Core.Models;
 using WoWSharpClient.Client;
 using WoWSharpClient.Models;
 using WoWSharpClient.Parsers;
+using Serilog;
 using WoWSharpClient.Utils;
 
 namespace WoWSharpClient.Handlers
@@ -81,19 +82,19 @@ namespace WoWSharpClient.Handlers
                             break;
                         case Opcode.SMSG_SPLINE_MOVE_SET_RUN_MODE:
                             ulong splineRunGuid = ReaderUtils.ReadPackedGuid(reader);
-                            Console.WriteLine($"{splineRunGuid} Now running");
+                            Log.Information($"{splineRunGuid} Now running");
                             break;
                         case Opcode.SMSG_SPLINE_MOVE_SET_WALK_MODE:
                             ulong splineWalkGuid = ReaderUtils.ReadPackedGuid(reader);
-                            Console.WriteLine($"{splineWalkGuid} Now walking");
+                            Log.Information($"{splineWalkGuid} Now walking");
                             break;
                         case Opcode.SMSG_SPLINE_MOVE_ROOT:
                             ulong splineMoveRootGuid = ReaderUtils.ReadPackedGuid(reader);
-                            Console.WriteLine($"{splineMoveRootGuid} Now rooted");
+                            Log.Information($"{splineMoveRootGuid} Now rooted");
                             break;
                         case Opcode.SMSG_SPLINE_MOVE_UNROOT:
                             ulong splineMoveUnrootGuid = ReaderUtils.ReadPackedGuid(reader);
-                            Console.WriteLine($"{splineMoveUnrootGuid} Now unrooted");
+                            Log.Information($"{splineMoveUnrootGuid} Now unrooted");
                             break;
                         case Opcode.MSG_MOVE_TIME_SKIPPED:
                             WoWSharpEventEmitter.Instance.FireOnMoveTimeSkipped(
@@ -164,13 +165,13 @@ namespace WoWSharpClient.Handlers
                             ParseMessageMove(reader);
                             break;
                         default:
-                            Console.WriteLine($"{opcode} not handled");
+                            Log.Information($"{opcode} not handled");
                             break;
                     }
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MovementHandler] {ex}");
+                    Log.Information($"[MovementHandler] {ex}");
                 }
             }
         }
@@ -231,7 +232,7 @@ namespace WoWSharpClient.Handlers
             var compressedOpCode = (Opcode)reader.ReadUInt16();
             var guid = ReaderUtils.ReadPackedGuid(reader);
 
-            //Console.WriteLine($"[MovementHandler] {compressedOpCode}");
+            //Log.Information($"[MovementHandler] {compressedOpCode}");
             switch (compressedOpCode)
             {
                 case Opcode.SMSG_MONSTER_MOVE:

--- a/Exports/WoWSharpClient/Handlers/ObjectUpdateHandler.cs
+++ b/Exports/WoWSharpClient/Handlers/ObjectUpdateHandler.cs
@@ -4,6 +4,7 @@ using WoWSharpClient.Client;
 using WoWSharpClient.Models;
 using WoWSharpClient.Parsers;
 using WoWSharpClient.Utils;
+using Serilog;
 using static GameData.Core.Enums.UpdateFields;
 
 namespace WoWSharpClient.Handlers
@@ -51,7 +52,7 @@ namespace WoWSharpClient.Handlers
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[{updateType}] {ex}");
+                Log.Error($"[{updateType}] {ex}");
             }
         }
 
@@ -741,7 +742,7 @@ namespace WoWSharpClient.Handlers
             EItemFields field
         )
         {
-            Console.WriteLine($"[ReadItemField] {field}");
+            Log.Error($"[ReadItemField] {field}");
             if (field <= EItemFields.ITEM_FIELD_OWNER + 0x01)
                 objectUpdate.UpdatedFields[(uint)field] = reader.ReadBytes(4);
             else if (field <= EItemFields.ITEM_FIELD_CONTAINED + 0x01)

--- a/Exports/WoWSharpClient/OpCodeDispatcher.cs
+++ b/Exports/WoWSharpClient/OpCodeDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿using GameData.Core.Enums;
 using WoWSharpClient.Handlers;
 using WoWSharpClient.Utils;
+using Serilog;
 
 namespace WoWSharpClient
 {
@@ -104,7 +105,7 @@ namespace WoWSharpClient
             }
             else
             {
-                //Console.WriteLine($"Unhandled opcode: {opcode} byte[{data.Length}]");
+                //Log.Error($"Unhandled opcode: {opcode} byte[{data.Length}]");
             }
         }
         private async Task Runner()
@@ -120,7 +121,7 @@ namespace WoWSharpClient
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine($"Error in OpCodeDispatcher.Runner: {e}\n");
+                        Log.Error($"Error in OpCodeDispatcher.Runner: {e}\n");
                     }
                 }
                 await Task.Delay(50);

--- a/Services/DecisionEngineService/Repository/MangosRepository.cs
+++ b/Services/DecisionEngineService/Repository/MangosRepository.cs
@@ -3,6 +3,7 @@ using Google.Protobuf.WellKnownTypes;
 using MySql.Data.MySqlClient;
 using MySql.Data.Types;
 using System.Data;
+using Serilog;
 
 namespace DecisionEngineService.Repository
 {
@@ -33,7 +34,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -73,7 +74,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -105,7 +106,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -137,7 +138,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -183,7 +184,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -222,7 +223,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -256,7 +257,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -289,7 +290,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -323,7 +324,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -368,7 +369,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -400,7 +401,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -442,7 +443,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -478,7 +479,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -512,7 +513,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -547,7 +548,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -598,7 +599,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -637,7 +638,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                    Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -682,7 +683,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -715,7 +716,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -750,7 +751,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -794,7 +795,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -845,7 +846,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -878,7 +879,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -911,7 +912,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -946,7 +947,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -985,7 +986,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1021,7 +1022,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1068,7 +1069,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1119,7 +1120,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1166,7 +1167,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1213,7 +1214,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1253,7 +1254,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1286,7 +1287,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1414,7 +1415,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1465,7 +1466,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1570,7 +1571,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1609,7 +1610,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1654,7 +1655,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1693,7 +1694,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1744,7 +1745,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1776,7 +1777,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1841,7 +1842,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1885,7 +1886,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1925,7 +1926,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -1959,7 +1960,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2009,7 +2010,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2043,7 +2044,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2076,7 +2077,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2116,7 +2117,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2150,7 +2151,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2184,7 +2185,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2236,7 +2237,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2303,7 +2304,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2345,7 +2346,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2378,7 +2379,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2416,7 +2417,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2449,7 +2450,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2483,7 +2484,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2517,7 +2518,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2555,7 +2556,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2598,7 +2599,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2633,7 +2634,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2669,7 +2670,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2720,7 +2721,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2754,7 +2755,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2800,7 +2801,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2852,7 +2853,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2888,7 +2889,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2923,7 +2924,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2956,7 +2957,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -2990,7 +2991,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3023,7 +3024,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3057,7 +3058,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3097,7 +3098,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3131,7 +3132,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3295,7 +3296,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3335,7 +3336,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3384,7 +3385,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3432,7 +3433,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3472,7 +3473,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3521,7 +3522,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3569,7 +3570,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3609,7 +3610,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3649,7 +3650,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3757,7 +3758,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3797,7 +3798,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3838,7 +3839,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3883,7 +3884,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3911,7 +3912,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3944,7 +3945,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -3992,7 +3993,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4029,7 +4030,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4066,7 +4067,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4101,7 +4102,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4136,7 +4137,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4170,7 +4171,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4206,7 +4207,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4247,7 +4248,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4282,7 +4283,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4322,7 +4323,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4356,7 +4357,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4395,7 +4396,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4431,7 +4432,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4466,7 +4467,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4501,7 +4502,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4536,7 +4537,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4570,7 +4571,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4605,7 +4606,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4639,7 +4640,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4672,7 +4673,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4706,7 +4707,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4745,7 +4746,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4778,7 +4779,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4816,7 +4817,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4854,7 +4855,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4890,7 +4891,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4928,7 +4929,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -4964,7 +4965,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5000,7 +5001,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5038,7 +5039,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5090,7 +5091,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5134,7 +5135,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5186,7 +5187,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5344,7 +5345,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5384,7 +5385,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5418,7 +5419,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5461,7 +5462,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5488,7 +5489,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5521,7 +5522,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5554,7 +5555,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5588,7 +5589,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5634,7 +5635,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5672,7 +5673,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5706,7 +5707,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5741,7 +5742,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5773,7 +5774,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5813,7 +5814,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5845,7 +5846,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5879,7 +5880,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5919,7 +5920,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5956,7 +5957,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -5992,7 +5993,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6034,7 +6035,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6061,7 +6062,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6113,7 +6114,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6146,7 +6147,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6179,7 +6180,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6213,7 +6214,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6246,7 +6247,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6280,7 +6281,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6349,7 +6350,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6383,7 +6384,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6425,7 +6426,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6458,7 +6459,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6510,7 +6511,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6544,7 +6545,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6581,7 +6582,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6785,7 +6786,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6820,7 +6821,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6856,7 +6857,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6891,7 +6892,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 
@@ -6924,7 +6925,7 @@ namespace DecisionEngineService.Repository
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ERROR] {ex.Message} {ex.StackTrace}");
+                    Log.Error($"[ERROR] {ex.Message} {ex.StackTrace}");
                 }
             }
 

--- a/Services/ForegroundBotRunner/Mem/Detour.cs
+++ b/Services/ForegroundBotRunner/Mem/Detour.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using Serilog;
 
 namespace ForegroundBotRunner.Mem
 {
@@ -38,7 +39,7 @@ namespace ForegroundBotRunner.Mem
 
         public void Apply()
         {
-            Console.WriteLine($"[DETOUR] Hack applied {Name}");
+            Log.Information($"[DETOUR] Hack applied {Name}");
             MemoryManager.WriteBytes(target, [.. newBytes]);
         }
 

--- a/Services/ForegroundBotRunner/Mem/Functions.cs
+++ b/Services/ForegroundBotRunner/Mem/Functions.cs
@@ -1,6 +1,7 @@
 ﻿using GameData.Core.Enums;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
+using Serilog;
 
 namespace ForegroundBotRunner.Mem
 {
@@ -193,7 +194,7 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("AccessViolationException occurred while trying to release corpse. Most likely, this is due to a transient error that caused the player pointer to temporarily equal IntPtr.Zero. The bot should keep trying to release and recover from this error.");
+                Log.Error("AccessViolationException occurred while trying to release corpse. Most likely, this is due to a transient error that caused the player pointer to temporarily equal IntPtr.Zero. The bot should keep trying to release and recover from this error.");
             }
         }
 

--- a/Services/ForegroundBotRunner/Mem/HackManager.cs
+++ b/Services/ForegroundBotRunner/Mem/HackManager.cs
@@ -1,4 +1,6 @@
-﻿namespace ForegroundBotRunner.Mem
+﻿using Serilog;
+
+namespace ForegroundBotRunner.Mem
 {
     internal static class HackManager
     {
@@ -6,7 +8,7 @@
 
         static internal void AddHack(Hack hack)
         {
-            Console.WriteLine($"[HACK MANAGER] Adding hack {hack.Name}");
+            Log.Information($"[HACK MANAGER] Adding hack {hack.Name}");
             Hacks.Add(hack);
             EnableHack(hack);
         }

--- a/Services/ForegroundBotRunner/Mem/Memory.cs
+++ b/Services/ForegroundBotRunner/Mem/Memory.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using Serilog;
 
 namespace ForegroundBotRunner.Mem
 {
@@ -84,12 +85,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Byte");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Byte");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -109,12 +110,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Short");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Short");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -134,12 +135,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Int");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Int");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -159,12 +160,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Uint");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Uint");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -184,12 +185,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Ulong");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Ulong");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -209,12 +210,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type IntPtr");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type IntPtr");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -234,12 +235,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type Float");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type Float");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -268,12 +269,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type string");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type string");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return "";
             }
         }
@@ -307,7 +308,7 @@ namespace ForegroundBotRunner.Mem
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -324,12 +325,12 @@ namespace ForegroundBotRunner.Mem
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access Violation on " + address.ToString("X") + " with type ItemCacheEntry");
+                Log.Error("Access Violation on " + address.ToString("X") + " with type ItemCacheEntry");
                 return default;
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
+                Log.Error($"[MEMORY]{e.Message}{e.InnerException.StackTrace}");
                 return default;
             }
         }
@@ -382,7 +383,7 @@ namespace ForegroundBotRunner.Mem
             }
             catch (FasmAssemblerException ex)
             {
-                Console.WriteLine(ex.StackTrace);
+                Log.Error(ex.StackTrace);
             }
 
             var start = Marshal.AllocHGlobal(byteCode.Length);

--- a/Services/ForegroundBotRunner/Mem/ThreadSynchronizer.cs
+++ b/Services/ForegroundBotRunner/Mem/ThreadSynchronizer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Serilog;
 
 namespace ForegroundBotRunner.Mem
 {
@@ -96,7 +97,7 @@ namespace ForegroundBotRunner.Mem
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[THREAD]{e.Message} {e.StackTrace}");
+                Log.Error($"[THREAD]{e.Message} {e.StackTrace}");
             }
 
             return CallWindowProc(oldCallback, hWnd, msg, wParam, lParam);

--- a/Services/ForegroundBotRunner/Objects/WoWObject.cs
+++ b/Services/ForegroundBotRunner/Objects/WoWObject.cs
@@ -3,6 +3,7 @@ using GameData.Core.Enums;
 using GameData.Core.Interfaces;
 using GameData.Core.Models;
 using System.Runtime.InteropServices;
+using Serilog;
 
 namespace ForegroundBotRunner.Objects
 {
@@ -76,11 +77,11 @@ namespace ForegroundBotRunner.Objects
             }
             catch (AccessViolationException)
             {
-                Console.WriteLine("Access violation on WoWObject.Position. Swallowing.");
+                Log.Error("Access violation on WoWObject.Position. Swallowing.");
             }
             catch (Exception e)
             {
-                Console.WriteLine($"[WOW OBJECT]{e.Message} {e.StackTrace}");
+                Log.Error($"[WOW OBJECT]{e.Message} {e.StackTrace}");
             }
             return new(0, 0, 0);
         }
@@ -108,7 +109,7 @@ namespace ForegroundBotRunner.Objects
                 }
                 catch (AccessViolationException)
                 {
-                    Console.WriteLine("Access violation on WoWObject.Facing. Swallowing.");
+                    Log.Error("Access violation on WoWObject.Facing. Swallowing.");
                     return 0;
                 }
             }
@@ -153,12 +154,12 @@ namespace ForegroundBotRunner.Objects
                 }
                 catch (AccessViolationException)
                 {
-                    Console.WriteLine("Access violation on WoWObject.Name. Swallowing.");
+                    Log.Error("Access violation on WoWObject.Name. Swallowing.");
                     return "";
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"Catchall exception {e.Message} {e.StackTrace}");
+                    Log.Error($"Catchall exception {e.Message} {e.StackTrace}");
                     return "";
                 }
             }

--- a/Services/ForegroundBotRunner/Statics/ObjectManager.cs
+++ b/Services/ForegroundBotRunner/Statics/ObjectManager.cs
@@ -6,6 +6,7 @@ using GameData.Core.Frames;
 using GameData.Core.Interfaces;
 using GameData.Core.Models;
 using System.Runtime.InteropServices;
+using Serilog;
 
 namespace ForegroundBotRunner.Statics
 {
@@ -608,7 +609,7 @@ namespace ForegroundBotRunner.Statics
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"[OBJECT MANAGER] {e}");
+                    Log.Error($"[OBJECT MANAGER] {e}");
                 }
             }
         }
@@ -747,7 +748,7 @@ namespace ForegroundBotRunner.Statics
             }
             catch (Exception e)
             {
-                Console.WriteLine($"OBJECT MANAGER: CallbackInternal => {e.StackTrace}");
+                Log.Error($"OBJECT MANAGER: CallbackInternal => {e.StackTrace}");
             }
 
             return 1;
@@ -945,7 +946,7 @@ namespace ForegroundBotRunner.Statics
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[OBJECT MANAGER]{ex.Message} {ex.StackTrace}");
+                Log.Error($"[OBJECT MANAGER]{ex.Message} {ex.StackTrace}");
             }
         }
 

--- a/Services/ForegroundBotRunner/Statics/WoWEventHandler.cs
+++ b/Services/ForegroundBotRunner/Statics/WoWEventHandler.cs
@@ -3,6 +3,7 @@ using GameData.Core.Enums;
 using GameData.Core.Interfaces;
 using Newtonsoft.Json;
 using System.Text.RegularExpressions;
+using Serilog;
 
 namespace ForegroundBotRunner.Statics
 {
@@ -230,7 +231,7 @@ namespace ForegroundBotRunner.Statics
         internal void TriggerCtmEvent(OnCtmArgs args)
         {
 #if DEBUG
-            Console.WriteLine(args.Position);
+            Log.Information(args.Position.ToString());
 #endif
             Task.Run(() => OnCtm?.Invoke(this, args));
         }
@@ -336,11 +337,11 @@ namespace ForegroundBotRunner.Statics
                 try
                 {
                     _evaluteEvent(parEvent, parArgs);
-                    //Console.WriteLine($"EVENT HANDLER: {parEvent} {JsonConvert.SerializeObject(parArgs)}");
+                    //Log.Error($"EVENT HANDLER: {parEvent} {JsonConvert.SerializeObject(parArgs)}");
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"EVENT HANDLER: {parEvent} {JsonConvert.SerializeObject(parArgs)} {ex.Message}");
+                    Log.Error($"EVENT HANDLER: {parEvent} {JsonConvert.SerializeObject(parArgs)} {ex.Message}");
                 }
             });
         }

--- a/Services/PathfindingService/Program.cs
+++ b/Services/PathfindingService/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Net.Sockets;
+using Serilog;
 
 namespace PathfindingService
 {
@@ -43,11 +44,11 @@ namespace PathfindingService
                 };
 
                 Process.Start(processInfo);
-                Console.WriteLine("PathfindingService has been launched externally.");
+                Log.Information("PathfindingService has been launched externally.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Failed to launch PathfindingService: {ex.Message}");
+                Log.Error($"Failed to launch PathfindingService: {ex.Message}");
             }
         }
     }

--- a/Services/PathfindingService/Repository/AdtGroundZLoader.cs
+++ b/Services/PathfindingService/Repository/AdtGroundZLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Text;
 using TerrainLib;
+using Serilog;
 
 public class AdtGroundZLoader
 {
@@ -26,7 +27,7 @@ public class AdtGroundZLoader
         {
             if (!StormLib.SFileOpenArchive(path, 0, MPQ_OPEN_FORCE_MPQ_V1, out var archive))
             {
-                Console.WriteLine($"[AdtGroundZLoader] Failed to open MPQ archive: {path}");
+                Log.Error($"[AdtGroundZLoader] Failed to open MPQ archive: {path}");
                 continue;
             }
 
@@ -37,13 +38,13 @@ public class AdtGroundZLoader
                     for (int tileY = 0; tileY < 64; tileY++)
                     {
                         string filePath = $"World\\Maps\\{mapDirName}\\{mapDirName}_{tileX}_{tileY}.adt";
-                        //Console.WriteLine($"[AdtGroundZLoader] Attempting to load file: {filePath}");
+                        //Log.Error($"[AdtGroundZLoader] Attempting to load file: {filePath}");
 
                         try
                         {
                             if (!StormLib.SFileOpenFileEx(archive, filePath, 0, out var fileHandle))
                             {
-                                Console.WriteLine($"[AdtGroundZLoader] Failed to open file: {filePath}");
+                                Log.Error($"[AdtGroundZLoader] Failed to open file: {filePath}");
                                 continue;
                             }
 
@@ -53,7 +54,7 @@ public class AdtGroundZLoader
                             uint len = StormLib.SFileGetFileSize(fileHandle);
                             if (len == 0)
                             {
-                                Console.WriteLine($"[AdtGroundZLoader] File size is zero (invalid): {filePath}");
+                                Log.Error($"[AdtGroundZLoader] File size is zero (invalid): {filePath}");
                                 StormLib.SFileCloseFile(fileHandle);
                                 continue;
                             }
@@ -61,7 +62,7 @@ public class AdtGroundZLoader
                             byte[] buf = new byte[len];
                             if (!StormLib.SFileReadFile(fileHandle, buf, len, out _, IntPtr.Zero))
                             {
-                                Console.WriteLine($"[AdtGroundZLoader] Failed to read file contents: {filePath}");
+                                Log.Error($"[AdtGroundZLoader] Failed to read file contents: {filePath}");
                                 StormLib.SFileCloseFile(fileHandle);
                                 continue;
                             }
@@ -73,7 +74,7 @@ public class AdtGroundZLoader
                             }
                             catch (Exception ex)
                             {
-                                Console.WriteLine($"[AdtGroundZLoader] Failed to parse ADT file {filePath}: {ex.Message} {ex.StackTrace}");
+                                Log.Error($"[AdtGroundZLoader] Failed to parse ADT file {filePath}: {ex.Message} {ex.StackTrace}");
                             }
                             finally
                             {
@@ -82,7 +83,7 @@ public class AdtGroundZLoader
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine($"[AdtGroundZLoader] Exception while handling file {filePath}: {ex}");
+                            Log.Error($"[AdtGroundZLoader] Exception while handling file {filePath}: {ex}");
                         }
                     }
                 }
@@ -370,7 +371,7 @@ namespace TerrainLib
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[AdtFile] Error reading ADT: {ex.Message}");
+                Log.Error($"[AdtFile] Error reading ADT: {ex.Message}");
                 throw;
             }
 

--- a/Services/PromptHandlingService/Providers/AzureAIPromptRunner.cs
+++ b/Services/PromptHandlingService/Providers/AzureAIPromptRunner.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Serilog;
 
 namespace PromptHandlingService.Providers
 {
@@ -52,11 +53,11 @@ namespace PromptHandlingService.Providers
                     }
                     else
                     {
-                        Console.WriteLine($"The request failed with status code: {response.StatusCode}");
-                        Console.WriteLine(response.Headers.ToString());
+                        Log.Error($"The request failed with status code: {response.StatusCode}");
+                        Log.Error(response.Headers.ToString());
 
                         string responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-                        Console.WriteLine(responseContent);
+                        Log.Error(responseContent);
                         tryCount++;
                     }
                 }

--- a/Services/StateManager/Repository/ActorDatabase.cs
+++ b/Services/StateManager/Repository/ActorDatabase.cs
@@ -1,6 +1,7 @@
 ﻿using GameData.Core.Enums;
 using Microsoft.Data.Sqlite;
 using System.Text;
+using Serilog;
 
 namespace StateManager.Repository
 {
@@ -114,7 +115,7 @@ namespace StateManager.Repository
                     );";
 
             tableCommand.ExecuteNonQuery();
-            Console.WriteLine("Actor table created successfully in Actors DB.");
+            Log.Information("Actor table created successfully in Actors DB.");
         }
 
         // Generate random personality values based on archetypes

--- a/Services/StateManager/Repository/ReamldRepository.cs
+++ b/Services/StateManager/Repository/ReamldRepository.cs
@@ -1,4 +1,5 @@
 ﻿using MySql.Data.MySqlClient;
+using Serilog;
 
 namespace StateManager.Repository
 {
@@ -21,7 +22,7 @@ namespace StateManager.Repository
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
+                Log.Error($"[MANGOS REPO]{ex.Message} {ex.StackTrace}");
             }
 
             return false;

--- a/Services/StateManager/Settings/StateManagerSettings.cs
+++ b/Services/StateManager/Settings/StateManagerSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Communication;
 using Newtonsoft.Json;
 using System.Reflection;
+using Serilog;
 
 namespace StateManager.Settings
 {
@@ -40,7 +41,7 @@ namespace StateManager.Settings
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.Error(ex);
             }
         }
         private StateManagerSettings() { }

--- a/Tests/WoWSharpClient.Tests/Util/FileReader.cs
+++ b/Tests/WoWSharpClient.Tests/Util/FileReader.cs
@@ -1,4 +1,6 @@
-﻿namespace WoWSharpClient.Tests.Util
+﻿using Serilog;
+
+namespace WoWSharpClient.Tests.Util
 {
     internal class FileReader
     {
@@ -16,7 +18,7 @@
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"An error occurred while reading the file: {ex.Message}");
+                Log.Error($"An error occurred while reading the file: {ex.Message}");
                 throw;
             }
         }


### PR DESCRIPTION
## Summary
- replace all Console.WriteLine calls with Serilog logging
- inject Serilog or ILogger where needed
- ensure services and clients log errors via Log.Error

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf29073d8832a94e016d03f0139bd