### PR TITLE
Add worker lifecycle logging

### DIFF
--- a/Services/DecisionEngineService/DecisionEngineWorker.cs
+++ b/Services/DecisionEngineService/DecisionEngineWorker.cs
@@ -6,14 +6,27 @@ namespace DecisionEngineService
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            _logger.LogInformation("DecisionEngineWorker is running.");
+
+            stoppingToken.Register(() =>
+                _logger.LogInformation("DecisionEngineWorker is stopping."));
+
             while (!stoppingToken.IsCancellationRequested)
             {
-                //if (_logger.IsEnabled(LogLevel.Information))
-                //{
-                //    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                //}
-                await Task.Delay(1000, stoppingToken);
+                try
+                {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+
+                    await Task.Delay(1000, stoppingToken);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && stoppingToken.IsCancellationRequested))
+                {
+                    _logger.LogError(ex, "Error occurred in DecisionEngineWorker loop.");
+                }
             }
+
+            _logger.LogInformation("DecisionEngineWorker has stopped.");
         }
     }
 }

--- a/Services/PathfindingService/PathfindingServiceWorker.cs
+++ b/Services/PathfindingService/PathfindingServiceWorker.cs
@@ -27,14 +27,27 @@ namespace PathfindingService
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            _logger.LogInformation("PathfindingServiceWorker is running.");
+
+            stoppingToken.Register(() =>
+                _logger.LogInformation("PathfindingServiceWorker is stopping."));
+
             while (!stoppingToken.IsCancellationRequested)
             {
-                //if (_logger.IsEnabled(LogLevel.Information))
-                //{
-                //    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                //}
-                await Task.Delay(1000, stoppingToken);
+                try
+                {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+
+                    await Task.Delay(1000, stoppingToken);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && stoppingToken.IsCancellationRequested))
+                {
+                    _logger.LogError(ex, "Error occurred in PathfindingServiceWorker loop.");
+                }
             }
+
+            _logger.LogInformation("PathfindingServiceWorker has stopped.");
         }
     }
 }

--- a/Services/PromptHandlingService/PromptHandlingServiceWorker.cs
+++ b/Services/PromptHandlingService/PromptHandlingServiceWorker.cs
@@ -6,14 +6,27 @@ namespace PromptHandlingService
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            _logger.LogInformation("PromptHandlingServiceWorker is running.");
+
+            stoppingToken.Register(() =>
+                _logger.LogInformation("PromptHandlingServiceWorker is stopping."));
+
             while (!stoppingToken.IsCancellationRequested)
             {
-                //if (_logger.IsEnabled(LogLevel.Information))
-                //{
-                //    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                //}
-                await Task.Delay(1000, stoppingToken);
+                try
+                {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                        _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+
+                    await Task.Delay(1000, stoppingToken);
+                }
+                catch (Exception ex) when (!(ex is OperationCanceledException && stoppingToken.IsCancellationRequested))
+                {
+                    _logger.LogError(ex, "Error occurred in PromptHandlingServiceWorker loop.");
+                }
             }
+
+            _logger.LogInformation("PromptHandlingServiceWorker has stopped.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable logging in `PathfindingServiceWorker`, `PromptHandlingServiceWorker`, and `DecisionEngineWorker`
- log start/stop events and heartbeat messages in `BackgroundBotWorker`

## Testing
- `dotnet test --no-build` *(fails: missing Windows SDK and Aspire.AppHost.Sdk)*

------
https://chatgpt.com/codex/tasks/task_e_687cfb490c5c832aac63272b8741c4b2