### PR TITLE
Add state history tracking

### DIFF
--- a/BloogBot.AI/StateMachine/BotActivityHistoryEntry.cs
+++ b/BloogBot.AI/StateMachine/BotActivityHistoryEntry.cs
@@ -1,0 +1,3 @@
+namespace BloogBot.AI.StateMachine;
+
+public record BotActivityHistoryEntry(BotActivity Activity, TimeSpan Duration);


### PR DESCRIPTION
## Summary
- track history of recent states
- store history entries with durations

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfb7b16f0832aa4cbbf022f29f40e