### PR TITLE
Add logging to CombatPredictionService

### DIFF
--- a/Services/DecisionEngineService/CombatPredictionService.cs
+++ b/Services/DecisionEngineService/CombatPredictionService.cs
@@ -23,7 +23,7 @@ namespace DecisionEngineService
             _processedDirectory = processedDirectory;
             _logger = logger;
 
-            _logger.LogInformation($"Starting CombatPredictionService| ConnectionString: {connectionString} DataDirectory: {dataDirectory} ProcessedDirectory: {processedDirectory}");
+            LogServiceConfiguration();
 
             // Load the initial trained model from the SQLite database
             _trainedModel = LoadModelFromDatabase();
@@ -33,6 +33,15 @@ namespace DecisionEngineService
 
             // Start monitoring for new `.bin` files
             MonitorForNewData();
+        }
+
+        private void LogServiceConfiguration()
+        {
+            _logger.LogInformation(
+                "Starting CombatPredictionService | ConnectionString: {ConnectionString} DataDirectory: {DataDirectory} ProcessedDirectory: {ProcessedDirectory}",
+                _connectionString,
+                _dataDirectory,
+                _processedDirectory);
         }
 
         // Method to load the model from the SQLite database
@@ -101,6 +110,7 @@ namespace DecisionEngineService
             try
             {
                 // Load and process the new data file
+                _logger.LogInformation("Processing data file {FilePath}", filePath);
                 IDataView newData = LoadData(filePath);
 
                 // Update the model with the new data
@@ -200,7 +210,7 @@ namespace DecisionEngineService
                 }
 
                 File.Move(filePath, destPath);
-                _logger.LogInformation($"Moved processed file to {destPath}");
+                _logger.LogInformation("Moved processed file from {FilePath} to {DestinationPath}", filePath, destPath);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- improve logging in `CombatPredictionService`

## Testing
- `dotnet test` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_687d59de8df0832a97282933862b2e27