### PR TITLE
Ensure PromptCache is disposed via DI

### DIFF
--- a/Services/PromptHandlingService/PromptHandlingServiceWorker.cs
+++ b/Services/PromptHandlingService/PromptHandlingServiceWorker.cs
@@ -1,11 +1,19 @@
+using PromptHandlingService.Cache;
+
 namespace PromptHandlingService
 {
-    public class PromptHandlingServiceWorker(ILogger<PromptHandlingServiceWorker> logger) : BackgroundService
+    public class PromptHandlingServiceWorker(ILogger<PromptHandlingServiceWorker> logger, PromptCache promptCache) : BackgroundService
     {
         private readonly ILogger<PromptHandlingServiceWorker> _logger = logger;
+        private readonly PromptCache _promptCache = promptCache;
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Prompt cache ready at {DatabasePath}", _promptCache.DatabasePath);
+            }
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 //if (_logger.IsEnabled(LogLevel.Information))

--- a/Services/PromptHandlingService/Properties/AssemblyInfo.cs
+++ b/Services/PromptHandlingService/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PromptHandlingService.Tests")]

--- a/Services/PromptHandlingService/ServiceCollectionExtensions.cs
+++ b/Services/PromptHandlingService/ServiceCollectionExtensions.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using PromptHandlingService.Cache;
+
+namespace PromptHandlingService;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddPromptHandlingServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<PromptCache>(provider =>
+        {
+            var environment = provider.GetRequiredService<IHostEnvironment>();
+            var configuredPath = configuration["PromptHandling:CachePath"];
+            var cachePath = ResolveCachePath(environment, configuredPath);
+            EnsureDirectoryExists(cachePath);
+            return new PromptCache(cachePath);
+        });
+
+        return services;
+    }
+
+    private static string ResolveCachePath(IHostEnvironment environment, string? configuredPath)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return Path.IsPathRooted(configuredPath)
+                ? configuredPath
+                : Path.Combine(environment.ContentRootPath, configuredPath);
+        }
+
+        return Path.Combine(environment.ContentRootPath, "prompt_cache.sqlite");
+    }
+
+    private static void EnsureDirectoryExists(string cachePath)
+    {
+        var directory = Path.GetDirectoryName(cachePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+}

--- a/Services/StateManager/Program.cs
+++ b/Services/StateManager/Program.cs
@@ -63,6 +63,7 @@ namespace StateManager
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
+                    services.AddPromptHandlingServices(hostContext.Configuration);
                     services.AddHostedService<StateManagerWorker>();
                     services.AddHostedService<DecisionEngineWorker>();
                     services.AddHostedService<PromptHandlingServiceWorker>();

--- a/Tests/PromptHandlingService.Tests/PromptCacheTests.cs
+++ b/Tests/PromptHandlingService.Tests/PromptCacheTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using PromptHandlingService.Cache;
+
+namespace PromptHandlingService.Tests;
+
+public class PromptCacheTests
+{
+    [Fact]
+    public void PromptCache_Dispose_ReleasesDatabaseFile()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"prompt-cache-{Guid.NewGuid():N}.db");
+
+        FileStream? lockedStream = null;
+        using (var cache = new PromptCache(dbPath))
+        {
+            cache.AddPrevious("prompt", "response");
+
+            var exceptionWhileOpen = Record.Exception(() =>
+            {
+                lockedStream = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            });
+
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.NotNull(exceptionWhileOpen);
+                Assert.IsType<IOException>(exceptionWhileOpen);
+            }
+            else
+            {
+                Assert.Null(exceptionWhileOpen);
+                lockedStream?.Dispose();
+                lockedStream = null;
+            }
+        }
+
+        lockedStream?.Dispose();
+
+        var exclusiveOpen = Record.Exception(() =>
+        {
+            using var stream = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        });
+
+        Assert.Null(exclusiveOpen);
+
+        var deleteException = Record.Exception(() => File.Delete(dbPath));
+        Assert.Null(deleteException);
+        Assert.False(File.Exists(dbPath));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IDisposable` on `PromptCache` and guard against use after disposal
- register the prompt cache through dependency injection so the service host disposes the SQLite connection
- expose internals to tests and add a regression test that confirms the cache releases its file handle

## Testing
- ⚠️ `MSBUILDTERMINALLOGGER=false dotnet test Tests/PromptHandlingService.Tests/PromptHandlingService.Tests.csproj --no-restore` *(fails: unable to reach https://api.nuget.org/v3/index.json because the proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c074aacc832aa1a6ebf6cedef9e1