### PR TITLE
Reuse shared world client factory in background worker

### DIFF
--- a/Exports/WoWSharpClient/Client/WoWClient.cs
+++ b/Exports/WoWSharpClient/Client/WoWClient.cs
@@ -14,12 +14,14 @@ namespace WoWSharpClient.Client
     {
         private string _ipAddress = "127.0.0.1";
         private AuthClient? _authClient;
-        private WorldClient? _worldClient;
+        private IWorldClient? _worldClient;
         private bool _isLoggedIn;
         private uint _pingCounter = 0;
         private bool _disposed;
 
         public bool IsLoggedIn => _isLoggedIn;
+
+        public IWorldClient? WorldClient => _worldClient;
 
         public void Dispose()
         {

--- a/Services/BackgroundBotRunner/BackgroundBotWorker.cs
+++ b/Services/BackgroundBotRunner/BackgroundBotWorker.cs
@@ -1,9 +1,10 @@
+using System;
+using System.Reactive.Linq;
 using BotRunner;
 using BotRunner.Clients;
 using PromptHandlingService;
 using WoWSharpClient;
 using WoWSharpClient.Client;
-using WoWSharpClient.Networking.ClientComponents;
 using WoWSharpClient.Networking.ClientComponents.I;
 
 namespace BackgroundBotRunner
@@ -17,38 +18,19 @@ namespace BackgroundBotRunner
         private readonly PathfindingClient _pathfindingClient;
         private readonly WoWClient _wowClient;
         private readonly CharacterStateUpdateClient _characterStateUpdateClient;
+        private readonly ILoggerFactory _loggerFactory;
 
         private readonly BotRunnerService _botRunner;
-        
-        // Use all network agents through the allAgents pattern
-        private readonly (
-            ITargetingNetworkClientComponent TargetingAgent,
-            IAttackNetworkClientComponent AttackAgent,
-            IQuestNetworkClientComponent QuestAgent,
-            ILootingNetworkClientComponent LootingAgent,
-            IGameObjectNetworkClientComponent GameObjectAgent,
-            IVendorNetworkClientComponent VendorAgent,
-            IFlightMasterNetworkClientComponent FlightMasterAgent,
-            IDeadActorNetworkClientComponent DeadActorAgent,
-            IInventoryNetworkClientComponent InventoryAgent,
-            IItemUseNetworkClientComponent ItemUseAgent,
-            IEquipmentNetworkClientComponent EquipmentAgent,
-            ISpellCastingNetworkClientComponent SpellCastingAgent,
-            IAuctionHouseNetworkClientComponent AuctionHouseAgent,
-            IBankNetworkClientComponent BankAgent,
-            IMailNetworkClientComponent MailAgent,
-            IGuildNetworkClientComponent GuildAgent,
-            IPartyNetworkClientComponent PartyAgent,
-            ITrainerNetworkClientComponent TrainerAgent,
-            ITalentNetworkClientComponent TalentAgent,
-            IProfessionsNetworkClientComponent ProfessionsAgent,
-            IEmoteNetworkClientComponent EmoteAgent
-        ) _allAgents;
+
+        private IAgentFactory? _agentFactory;
+        private IDisposable? _worldDisconnectSubscription;
+        private IWorldClient? _activeWorldClient;
 
         private CancellationToken _stoppingToken;
 
         public BackgroundBotWorker(ILoggerFactory loggerFactory, IConfiguration configuration)
         {
+            _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<BackgroundBotWorker>();
 
             _promptRunner = PromptRunnerFactory.GetOllamaPromptRunner(new Uri(configuration["Ollama:BaseUri"]), configuration["Ollama:Model"]);
@@ -59,10 +41,6 @@ namespace BackgroundBotRunner
             _wowClient.SetIpAddress(configuration["RealmEndpoint:IpAddress"]);
             WoWSharpObjectManager.Instance.Initialize(_wowClient, _pathfindingClient, loggerFactory.CreateLogger<WoWSharpObjectManager>());
             _botRunner = new BotRunnerService(WoWSharpObjectManager.Instance, _characterStateUpdateClient, _pathfindingClient);
-            
-            // Initialize all network agents including the new ones
-            var worldClient = WoWClientFactory.CreateWorldClient();
-            _allAgents = WoWClientFactory.CreateAllNetworkClientComponents(worldClient, loggerFactory);
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -75,12 +53,14 @@ namespace BackgroundBotRunner
 
                 while (!stoppingToken.IsCancellationRequested)
                 {
+                    MaintainAgentFactory();
+
                     // Example: Demonstrate agent functionality through internal logic
                     if (_wowClient.IsWorldConnected())
                     {
                         // This is where you would integrate targeting, attacking, questing, looting, game object interaction,
                         // vendor operations, flight master usage, and death handling with your bot logic
-                        
+
                         // Example usage (commented out to avoid actual actions):
                         // await _combatExample.EngageCombatAsync(enemyGuid);
                         // await InternalProcessQuestsAsync();
@@ -89,29 +69,29 @@ namespace BackgroundBotRunner
                         // await InternalBuySuppliesAsync();
                         // await InternalTakeFlight();
                         // await InternalHandleDeathAsync();
-                        
-                        // Access individual agents like this:
-                        // var targetingAgent = _allAgents.TargetingAgent;
-                        // var attackAgent = _allAgents.AttackAgent;
-                        // var questAgent = _allAgents.QuestAgent;
-                        // var lootingAgent = _allAgents.LootingAgent;
-                        // var gameObjectAgent = _allAgents.GameObjectAgent;
-                        // var vendorAgent = _allAgents.VendorAgent;
-                        // var flightMasterAgent = _allAgents.FlightMasterAgent;
-                        // var deadActorAgent = _allAgents.DeadActorAgent;
-                        // var inventoryAgent = _allAgents.InventoryAgent;
-                        // var itemUseAgent = _allAgents.ItemUseAgent;
-                        // var equipmentAgent = _allAgents.EquipmentAgent;
-                        // var spellCastingAgent = _allAgents.SpellCastingAgent;
-                        // var auctionHouseAgent = _allAgents.AuctionHouseAgent;
-                        // var bankAgent = _allAgents.BankAgent;
-                        // var mailAgent = _allAgents.MailAgent;
-                        // var guildAgent = _allAgents.GuildAgent;
-                        // var partyAgent = _allAgents.PartyAgent; // Accessing the party agent
-                        // var trainerAgent = _allAgents.TrainerAgent; // Accessing the trainer agent
-                        // var talentAgent = _allAgents.TalentAgent; // Accessing the talent agent
-                        // var professionsAgent = _allAgents.ProfessionsAgent; // Accessing the professions agent
-                        // var emoteAgent = _allAgents.EmoteAgent; // Accessing the emote agent
+
+                        // Access individual agents like this once the factory has been initialized:
+                        // var targetingAgent = _agentFactory?.TargetingAgent;
+                        // var attackAgent = _agentFactory?.AttackAgent;
+                        // var questAgent = _agentFactory?.QuestAgent;
+                        // var lootingAgent = _agentFactory?.LootingAgent;
+                        // var gameObjectAgent = _agentFactory?.GameObjectAgent;
+                        // var vendorAgent = _agentFactory?.VendorAgent;
+                        // var flightMasterAgent = _agentFactory?.FlightMasterAgent;
+                        // var deadActorAgent = _agentFactory?.DeadActorAgent;
+                        // var inventoryAgent = _agentFactory?.InventoryAgent;
+                        // var itemUseAgent = _agentFactory?.ItemUseAgent;
+                        // var equipmentAgent = _agentFactory?.EquipmentAgent;
+                        // var spellCastingAgent = _agentFactory?.SpellCastingAgent;
+                        // var auctionHouseAgent = _agentFactory?.AuctionHouseAgent;
+                        // var bankAgent = _agentFactory?.BankAgent;
+                        // var mailAgent = _agentFactory?.MailAgent;
+                        // var guildAgent = _agentFactory?.GuildAgent;
+                        // var partyAgent = _agentFactory?.PartyAgent; // Accessing the party agent
+                        // var trainerAgent = _agentFactory?.TrainerAgent; // Accessing the trainer agent
+                        // var talentAgent = _agentFactory?.TalentAgent; // Accessing the talent agent
+                        // var professionsAgent = _agentFactory?.ProfessionsAgent; // Accessing the professions agent
+                        // var emoteAgent = _agentFactory?.EmoteAgent; // Accessing the emote agent
                     }
 
                     await Task.Delay(100, stoppingToken);
@@ -121,6 +101,76 @@ namespace BackgroundBotRunner
             {
                 _logger.LogError(ex, "Error in BackgroundBotWorker");
             }
+        }
+
+        private void MaintainAgentFactory()
+        {
+            var worldClient = _wowClient.WorldClient;
+
+            if (worldClient?.IsConnected == true)
+            {
+                EnsureAgentFactory(worldClient);
+            }
+            else
+            {
+                ResetAgentFactory();
+            }
+        }
+
+        private void EnsureAgentFactory(IWorldClient worldClient)
+        {
+            if (_agentFactory != null && ReferenceEquals(worldClient, _activeWorldClient))
+            {
+                return;
+            }
+
+            ResetAgentFactory();
+
+            _agentFactory = WoWClientFactory.CreateNetworkClientComponentFactory(worldClient, _loggerFactory);
+            _activeWorldClient = worldClient;
+
+            try
+            {
+                _worldDisconnectSubscription = worldClient.WhenDisconnected?.Subscribe(_ =>
+                {
+                    _logger.LogInformation("World client disconnected. Resetting agent factory.");
+                    ResetAgentFactory();
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to subscribe to world client disconnection notifications.");
+            }
+
+            _logger.LogInformation("Initialized network client component factory using active world client.");
+        }
+
+        private void ResetAgentFactory()
+        {
+            if (_agentFactory == null && _worldDisconnectSubscription == null && _activeWorldClient == null)
+            {
+                return;
+            }
+
+            if (_agentFactory is IDisposable disposableFactory)
+            {
+                try
+                {
+                    disposableFactory.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error disposing agent factory.");
+                }
+            }
+
+            _agentFactory = null;
+            _activeWorldClient = null;
+
+            _worldDisconnectSubscription?.Dispose();
+            _worldDisconnectSubscription = null;
+
+            _logger.LogInformation("Cleared network client component factory state.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose the active world client via a new `WorldClient` property so other services can reuse the authenticated connection
- update the background bot worker to wait for the live world client, cache a shared agent factory built from it, and reset the factory when the connection drops

## Testing
- `dotnet test WestworldOfWarcraft.sln` *(fails: Windows-targeted native projects require Windows tooling)*
- `dotnet test WestworldOfWarcraft.sln -p:EnableWindowsTargeting=true` *(fails: Windows desktop tooling and testhost .NET 8 runtime unavailable in container)*
- `dotnet build Services/BackgroundBotRunner/BackgroundBotRunner.csproj` *(fails: existing PromptHandlingService accessibility error)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c9e92f7c832aa3905a1c2eb0fe7e