### PR TITLE
Include social agents in network component tuples

### DIFF
--- a/Exports/WoWSharpClient/Client/WoWClientFactory.cs
+++ b/Exports/WoWSharpClient/Client/WoWClientFactory.cs
@@ -452,6 +452,7 @@ namespace WoWSharpClient.Client
         public static (
             ITargetingNetworkClientComponent TargetingAgent,
             IAttackNetworkClientComponent AttackAgent,
+            IChatNetworkClientComponent ChatAgent,
             IQuestNetworkClientComponent QuestAgent,
             ILootingNetworkClientComponent LootingAgent,
             IGameObjectNetworkClientComponent GameObjectAgent,
@@ -470,7 +471,11 @@ namespace WoWSharpClient.Client
             ITrainerNetworkClientComponent TrainerAgent,
             ITalentNetworkClientComponent TalentAgent,
             IProfessionsNetworkClientComponent ProfessionsAgent,
-            IEmoteNetworkClientComponent EmoteAgent
+            IEmoteNetworkClientComponent EmoteAgent,
+            IGossipNetworkClientComponent GossipAgent,
+            IFriendNetworkClientComponent FriendAgent,
+            IIgnoreNetworkClientComponent IgnoreAgent,
+            ITradeNetworkClientComponent TradeAgent
         ) CreateAllNetworkClientComponents(IWorldClient worldClient, ILoggerFactory? loggerFactory = null)
         {
             return AgentFactory.CreateAllNetworkClientComponents(worldClient, loggerFactory);

--- a/Exports/WoWSharpClient/Networking/ClientComponents/AgentFactory.cs
+++ b/Exports/WoWSharpClient/Networking/ClientComponents/AgentFactory.cs
@@ -679,6 +679,7 @@ namespace WoWSharpClient.Networking.ClientComponents
         public static (
             ITargetingNetworkClientComponent TargetingAgent,
             IAttackNetworkClientComponent AttackAgent,
+            IChatNetworkClientComponent ChatAgent,
             IQuestNetworkClientComponent QuestAgent,
             ILootingNetworkClientComponent LootingAgent,
             IGameObjectNetworkClientComponent GameObjectAgent,
@@ -697,12 +698,17 @@ namespace WoWSharpClient.Networking.ClientComponents
             ITrainerNetworkClientComponent TrainerAgent,
             ITalentNetworkClientComponent TalentAgent,
             IProfessionsNetworkClientComponent ProfessionsAgent,
-            IEmoteNetworkClientComponent EmoteAgent
+            IEmoteNetworkClientComponent EmoteAgent,
+            IGossipNetworkClientComponent GossipAgent,
+            IFriendNetworkClientComponent FriendAgent,
+            IIgnoreNetworkClientComponent IgnoreAgent,
+            ITradeNetworkClientComponent TradeAgent
         ) CreateAllNetworkClientComponents(IWorldClient worldClient, ILoggerFactory? loggerFactory = null)
         {
             return (
                 CreateTargetingNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateAttackNetworkClientComponentForClient(worldClient, loggerFactory),
+                CreateChatNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateQuestNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateLootingNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateGameObjectNetworkClientComponentForClient(worldClient, loggerFactory),
@@ -721,7 +727,11 @@ namespace WoWSharpClient.Networking.ClientComponents
                 CreateTrainerNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateTalentNetworkClientComponentForClient(worldClient, loggerFactory),
                 CreateProfessionsNetworkClientComponentForClient(worldClient, loggerFactory),
-                CreateEmoteNetworkClientComponentForClient(worldClient, loggerFactory)
+                CreateEmoteNetworkClientComponentForClient(worldClient, loggerFactory),
+                CreateGossipNetworkClientComponentForClient(worldClient, loggerFactory),
+                CreateFriendNetworkClientComponentForClient(worldClient, loggerFactory),
+                CreateIgnoreNetworkClientComponentForClient(worldClient, loggerFactory),
+                CreateTradeNetworkClientComponentForClient(worldClient, loggerFactory)
             );
         }
 

--- a/Services/BackgroundBotRunner/BackgroundBotWorker.cs
+++ b/Services/BackgroundBotRunner/BackgroundBotWorker.cs
@@ -24,6 +24,7 @@ namespace BackgroundBotRunner
         private readonly (
             ITargetingNetworkClientComponent TargetingAgent,
             IAttackNetworkClientComponent AttackAgent,
+            IChatNetworkClientComponent ChatAgent,
             IQuestNetworkClientComponent QuestAgent,
             ILootingNetworkClientComponent LootingAgent,
             IGameObjectNetworkClientComponent GameObjectAgent,
@@ -42,7 +43,11 @@ namespace BackgroundBotRunner
             ITrainerNetworkClientComponent TrainerAgent,
             ITalentNetworkClientComponent TalentAgent,
             IProfessionsNetworkClientComponent ProfessionsAgent,
-            IEmoteNetworkClientComponent EmoteAgent
+            IEmoteNetworkClientComponent EmoteAgent,
+            IGossipNetworkClientComponent GossipAgent,
+            IFriendNetworkClientComponent FriendAgent,
+            IIgnoreNetworkClientComponent IgnoreAgent,
+            ITradeNetworkClientComponent TradeAgent
         ) _allAgents;
 
         private CancellationToken _stoppingToken;

--- a/Tests/WoWSharpClient.Tests/Agent/AgentFactoryTests.cs
+++ b/Tests/WoWSharpClient.Tests/Agent/AgentFactoryTests.cs
@@ -542,11 +542,12 @@ namespace WoWSharpClient.Tests.Agent
         public void CreateAllNetworkClientComponents_WithLoggerFactory_ReturnsAllAgents()
         {
             // Act
-            var (targetingAgent, attackAgent, questAgent, lootingAgent, gameObjectAgent, vendorAgent, flightMasterAgent, deadActorAgent, inventoryAgent, itemUseAgent, equipmentAgent, spellCastingAgent, auctionHouseAgent, bankAgent, mailAgent, guildAgent, partyAgent, trainerAgent, talentAgent, professionsAgent, emoteAgent) = AgentFactory.CreateAllNetworkClientComponents(_mockWorldClient.Object, _mockLoggerFactory.Object);
+            var (targetingAgent, attackAgent, chatAgent, questAgent, lootingAgent, gameObjectAgent, vendorAgent, flightMasterAgent, deadActorAgent, inventoryAgent, itemUseAgent, equipmentAgent, spellCastingAgent, auctionHouseAgent, bankAgent, mailAgent, guildAgent, partyAgent, trainerAgent, talentAgent, professionsAgent, emoteAgent, gossipAgent, friendAgent, ignoreAgent, tradeAgent) = AgentFactory.CreateAllNetworkClientComponents(_mockWorldClient.Object, _mockLoggerFactory.Object);
 
             // Assert
             Assert.NotNull(targetingAgent);
             Assert.NotNull(attackAgent);
+            Assert.NotNull(chatAgent);
             Assert.NotNull(questAgent);
             Assert.NotNull(lootingAgent);
             Assert.NotNull(gameObjectAgent);
@@ -566,8 +567,13 @@ namespace WoWSharpClient.Tests.Agent
             Assert.NotNull(talentAgent);
             Assert.NotNull(professionsAgent);
             Assert.NotNull(emoteAgent);
+            Assert.NotNull(gossipAgent);
+            Assert.NotNull(friendAgent);
+            Assert.NotNull(ignoreAgent);
+            Assert.NotNull(tradeAgent);
             Assert.IsType<TargetingNetworkClientComponent>(targetingAgent);
             Assert.IsType<AttackNetworkClientComponent>(attackAgent);
+            Assert.IsType<ChatNetworkClientComponent>(chatAgent);
             Assert.IsType<QuestNetworkClientComponent>(questAgent);
             Assert.IsType<LootingNetworkClientComponent>(lootingAgent);
             Assert.IsType<GameObjectNetworkClientComponent>(gameObjectAgent);
@@ -587,17 +593,22 @@ namespace WoWSharpClient.Tests.Agent
             Assert.IsType<TalentNetworkClientComponent>(talentAgent);
             Assert.IsType<ProfessionsNetworkClientComponent>(professionsAgent);
             Assert.IsType<EmoteNetworkClientComponent>(emoteAgent);
+            Assert.IsType<GossipNetworkClientComponent>(gossipAgent);
+            Assert.IsType<FriendNetworkClientComponent>(friendAgent);
+            Assert.IsType<IgnoreNetworkClientComponent>(ignoreAgent);
+            Assert.IsType<TradeNetworkClientComponent>(tradeAgent);
         }
 
         [Fact]
         public void CreateAllNetworkClientComponents_WithoutLoggerFactory_ReturnsAllAgents()
         {
             // Act
-            var (targetingAgent, attackAgent, questAgent, lootingAgent, gameObjectAgent, vendorAgent, flightMasterAgent, deadActorAgent, inventoryAgent, itemUseAgent, equipmentAgent, spellCastingAgent, auctionHouseAgent, bankAgent, mailAgent, guildAgent, partyAgent, trainerAgent, talentAgent, professionsAgent, emoteAgent) = AgentFactory.CreateAllNetworkClientComponents(_mockWorldClient.Object, null);
+            var (targetingAgent, attackAgent, chatAgent, questAgent, lootingAgent, gameObjectAgent, vendorAgent, flightMasterAgent, deadActorAgent, inventoryAgent, itemUseAgent, equipmentAgent, spellCastingAgent, auctionHouseAgent, bankAgent, mailAgent, guildAgent, partyAgent, trainerAgent, talentAgent, professionsAgent, emoteAgent, gossipAgent, friendAgent, ignoreAgent, tradeAgent) = AgentFactory.CreateAllNetworkClientComponents(_mockWorldClient.Object, null);
 
             // Assert
             Assert.NotNull(targetingAgent);
             Assert.NotNull(attackAgent);
+            Assert.NotNull(chatAgent);
             Assert.NotNull(questAgent);
             Assert.NotNull(lootingAgent);
             Assert.NotNull(gameObjectAgent);
@@ -617,8 +628,13 @@ namespace WoWSharpClient.Tests.Agent
             Assert.NotNull(talentAgent);
             Assert.NotNull(professionsAgent);
             Assert.NotNull(emoteAgent);
+            Assert.NotNull(gossipAgent);
+            Assert.NotNull(friendAgent);
+            Assert.NotNull(ignoreAgent);
+            Assert.NotNull(tradeAgent);
             Assert.IsType<TargetingNetworkClientComponent>(targetingAgent);
             Assert.IsType<AttackNetworkClientComponent>(attackAgent);
+            Assert.IsType<ChatNetworkClientComponent>(chatAgent);
             Assert.IsType<QuestNetworkClientComponent>(questAgent);
             Assert.IsType<LootingNetworkClientComponent>(lootingAgent);
             Assert.IsType<GameObjectNetworkClientComponent>(gameObjectAgent);
@@ -638,6 +654,10 @@ namespace WoWSharpClient.Tests.Agent
             Assert.IsType<TalentNetworkClientComponent>(talentAgent);
             Assert.IsType<ProfessionsNetworkClientComponent>(professionsAgent);
             Assert.IsType<EmoteNetworkClientComponent>(emoteAgent);
+            Assert.IsType<GossipNetworkClientComponent>(gossipAgent);
+            Assert.IsType<FriendNetworkClientComponent>(friendAgent);
+            Assert.IsType<IgnoreNetworkClientComponent>(ignoreAgent);
+            Assert.IsType<TradeNetworkClientComponent>(tradeAgent);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- include chat, gossip, friend, ignore, and trade agents in the aggregated network component tuple
- expose the expanded tuple via WoWClientFactory and BackgroundBotWorker
- extend agent factory tests to validate the additional social agents are instantiated

## Testing
- `dotnet test Tests/WoWSharpClient.Tests/WoWSharpClient.Tests.csproj` *(fails: missing Microsoft.NETCore.App 8.0 runtime in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c9fa2edc832a820ea40ce1354079